### PR TITLE
Draft: add core agent-plane schema scaffolds

### DIFF
--- a/asyncapi.agent-plane.patch.yaml
+++ b/asyncapi.agent-plane.patch.yaml
@@ -1,0 +1,27 @@
+# additive AsyncAPI patch fragment for the core agent-plane schema family
+channels:
+  srcos.v2.session.events:
+    publish:
+      message:
+        name: SessionEvent
+        payload: { $ref: './schemas/EventEnvelope.json' }
+  srcos.v2.execution.events:
+    publish:
+      message:
+        name: ExecutionEvent
+        payload: { $ref: './schemas/EventEnvelope.json' }
+  srcos.v2.skill.events:
+    publish:
+      message:
+        name: SkillEvent
+        payload: { $ref: './schemas/EventEnvelope.json' }
+  srcos.v2.memory.events:
+    publish:
+      message:
+        name: MemoryEvent
+        payload: { $ref: './schemas/EventEnvelope.json' }
+  srcos.v2.receipt.events:
+    publish:
+      message:
+        name: ReceiptEvent
+        payload: { $ref: './schemas/EventEnvelope.json' }

--- a/openapi.agent-plane.patch.yaml
+++ b/openapi.agent-plane.patch.yaml
@@ -1,0 +1,56 @@
+# additive OpenAPI patch fragment for the core agent-plane schema family
+paths:
+  /v2/sessions:
+    post:
+      operationId: upsertAgentSession
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: './schemas/AgentSession.json' }
+      responses:
+        '200': { description: ok }
+  /v2/execution/decide:
+    post:
+      operationId: decideExecution
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: './schemas/ExecutionDecision.json' }
+      responses:
+        '200':
+          description: execution decision
+          content:
+            application/json:
+              schema: { $ref: './schemas/ExecutionDecision.json' }
+  /v2/skills:
+    post:
+      operationId: upsertSkillManifest
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: './schemas/SkillManifest.json' }
+      responses:
+        '200': { description: ok }
+  /v2/memory:
+    post:
+      operationId: upsertMemoryEntry
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: './schemas/MemoryEntry.json' }
+      responses:
+        '200': { description: ok }
+  /v2/receipts/session:
+    post:
+      operationId: recordSessionReceipt
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: './schemas/SessionReceipt.json' }
+      responses:
+        '200': { description: ok }

--- a/schemas/AgentSession.json
+++ b/schemas/AgentSession.json
@@ -1,0 +1,157 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.srcos.ai/v2/AgentSession.json",
+  "title": "AgentSession",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "id",
+    "type",
+    "specVersion",
+    "role",
+    "status",
+    "mode",
+    "workspaceRef",
+    "substrate",
+    "surface",
+    "skillRefs",
+    "memoryRefs",
+    "decisionRefs",
+    "time"
+  ],
+  "properties": {
+    "id": {
+      "type": "string",
+      "pattern": "^urn:srcos:session:"
+    },
+    "type": {
+      "const": "AgentSession"
+    },
+    "specVersion": {
+      "type": "string"
+    },
+    "parentSessionRef": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "pattern": "^urn:srcos:session:"
+    },
+    "role": {
+      "enum": [
+        "main",
+        "explorer",
+        "planner",
+        "executor",
+        "reviewer",
+        "auditor",
+        "reverser",
+        "custom"
+      ]
+    },
+    "status": {
+      "enum": [
+        "created",
+        "waiting",
+        "running",
+        "paused",
+        "completed",
+        "failed",
+        "canceled",
+        "merged",
+        "reversed"
+      ]
+    },
+    "mode": {
+      "enum": [
+        "plan",
+        "ask",
+        "execute",
+        "review"
+      ]
+    },
+    "workspaceRef": {
+      "type": "string"
+    },
+    "worktreeRef": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "substrate": {
+      "enum": [
+        "local",
+        "remote-local",
+        "cloud",
+        "background",
+        "event-pushed",
+        "ci"
+      ]
+    },
+    "surface": {
+      "$ref": "ExecutionSurface.json"
+    },
+    "provider": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "skillRefs": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "pattern": "^urn:srcos:skill:"
+      }
+    },
+    "memoryRefs": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "pattern": "^urn:srcos:memory:"
+      }
+    },
+    "transcriptRef": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "pattern": "^urn:srcos:transcript:"
+    },
+    "decisionRefs": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "pattern": "^urn:srcos:exec-decision:"
+      }
+    },
+    "telemetryRefs": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "pattern": "^urn:srcos:telemetry:"
+      }
+    },
+    "time": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "startedAt"
+      ],
+      "properties": {
+        "startedAt": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "endedAt": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "date-time"
+        }
+      }
+    }
+  }
+}

--- a/schemas/ExecutionDecision.json
+++ b/schemas/ExecutionDecision.json
@@ -1,0 +1,87 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.srcos.ai/v2/ExecutionDecision.json",
+  "title": "ExecutionDecision",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "id",
+    "type",
+    "specVersion",
+    "sessionRef",
+    "decision",
+    "reason",
+    "issuedAt",
+    "decisionHash"
+  ],
+  "properties": {
+    "id": {
+      "type": "string",
+      "pattern": "^urn:srcos:exec-decision:"
+    },
+    "type": {
+      "const": "ExecutionDecision"
+    },
+    "specVersion": {
+      "type": "string"
+    },
+    "sessionRef": {
+      "type": "string",
+      "pattern": "^urn:srcos:session:"
+    },
+    "toolRequestRef": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "pattern": "^urn:srcos:tool:"
+    },
+    "decision": {
+      "enum": [
+        "allow",
+        "deny",
+        "ask",
+        "defer",
+        "rewrite"
+      ]
+    },
+    "reason": {
+      "type": "string"
+    },
+    "updatedInput": {
+      "type": [
+        "object",
+        "null"
+      ],
+      "additionalProperties": true
+    },
+    "policyRef": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "pattern": "^urn:srcos:policy:"
+    },
+    "obligations": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "issuedAt": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "expiresAt": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "format": "date-time"
+    },
+    "decisionHash": {
+      "type": "string",
+      "pattern": "^sha256:"
+    }
+  }
+}

--- a/schemas/ExecutionSurface.json
+++ b/schemas/ExecutionSurface.json
@@ -1,0 +1,77 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.srcos.ai/v2/ExecutionSurface.json",
+  "title": "ExecutionSurface",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "pty",
+    "workdir",
+    "background",
+    "reviewOnly",
+    "worktreeStrategy",
+    "sandboxMode",
+    "networkMode",
+    "egressAllowlist",
+    "elevated"
+  ],
+  "properties": {
+    "pty": {
+      "type": "boolean"
+    },
+    "workdir": {
+      "type": "string"
+    },
+    "background": {
+      "type": "boolean"
+    },
+    "reviewOnly": {
+      "type": "boolean"
+    },
+    "worktreeStrategy": {
+      "enum": [
+        "none",
+        "existing",
+        "create-temp",
+        "named"
+      ]
+    },
+    "sandboxMode": {
+      "enum": [
+        "none",
+        "user",
+        "container",
+        "vm",
+        "browser-sandbox"
+      ]
+    },
+    "networkMode": {
+      "enum": [
+        "none",
+        "allowlist",
+        "full"
+      ]
+    },
+    "egressAllowlist": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "elevated": {
+      "type": "boolean"
+    },
+    "protectedPaths": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "approvalProfile": {
+      "type": [
+        "string",
+        "null"
+      ]
+    }
+  }
+}

--- a/schemas/ExperimentFlag.json
+++ b/schemas/ExperimentFlag.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.srcos.ai/v2/ExperimentFlag.json",
+  "title": "ExperimentFlag",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["id","type","specVersion","name","state"],
+  "properties": {
+    "id": {"type": "string", "pattern": "^urn:srcos:flag:"},
+    "type": {"const": "ExperimentFlag"},
+    "specVersion": {"type": "string"},
+    "name": {"type": "string"},
+    "state": {"enum": ["off","shadow","internal","beta","on","retired"]},
+    "owner": {"type": ["string","null"]},
+    "description": {"type": ["string","null"]},
+    "killSwitch": {"type": "boolean"}
+  }
+}

--- a/schemas/FrustrationSignal.json
+++ b/schemas/FrustrationSignal.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.srcos.ai/v2/FrustrationSignal.json",
+  "title": "FrustrationSignal",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["id","type","specVersion","sessionRef","signal","capturedAt"],
+  "properties": {
+    "id": {"type": "string", "pattern": "^urn:srcos:frustration:"},
+    "type": {"const": "FrustrationSignal"},
+    "specVersion": {"type": "string"},
+    "sessionRef": {"type": "string", "pattern": "^urn:srcos:session:"},
+    "signal": {"enum": ["strong-negative-language","cancel","repeated-failure","tool-loop","user-interrupt"]},
+    "count": {"type": ["integer","null"], "minimum": 0},
+    "capturedAt": {"type": "string", "format": "date-time"}
+  }
+}

--- a/schemas/MemoryEntry.json
+++ b/schemas/MemoryEntry.json
@@ -1,0 +1,115 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.srcos.ai/v2/MemoryEntry.json",
+  "title": "MemoryEntry",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "id",
+    "type",
+    "specVersion",
+    "kind",
+    "namespace",
+    "key",
+    "payloadRef",
+    "citationRefs",
+    "scope",
+    "freshness"
+  ],
+  "properties": {
+    "id": {
+      "type": "string",
+      "pattern": "^urn:srcos:memory:"
+    },
+    "type": {
+      "const": "MemoryEntry"
+    },
+    "specVersion": {
+      "type": "string"
+    },
+    "kind": {
+      "enum": [
+        "rule",
+        "learned",
+        "recap"
+      ]
+    },
+    "namespace": {
+      "type": "string"
+    },
+    "key": {
+      "type": "string"
+    },
+    "payloadRef": {
+      "type": "string"
+    },
+    "authoritativeRef": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "citationRefs": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "scope": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "workspace",
+        "pathPrefixes"
+      ],
+      "properties": {
+        "workspace": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "pathPrefixes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sessionRef": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "pattern": "^urn:srcos:session:"
+        }
+      }
+    },
+    "freshness": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "learnedAt"
+      ],
+      "properties": {
+        "learnedAt": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "reviewedAt": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "date-time"
+        },
+        "ttl": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "minimum": 0
+        }
+      }
+    }
+  }
+}

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -1,0 +1,39 @@
+# Agent-Plane Schema Documentation
+
+## Overview
+This document provides comprehensive details about the Agent-Plane schemas, including usage examples, URN patterns, spec metadata explanation, and validation instructions.
+
+## Usage Examples
+### Example 1: Basic Usage
+```json
+{
+  "exampleKey": "exampleValue"
+}
+```
+
+### Example 2: Advanced Usage
+```json
+{
+  "advancedKey": [{
+    "nestedKey": "nestedValue"
+  }]
+}
+```
+
+## URN Patterns
+The URN patterns for the agent-plane schemas follow the structure: `urn:example:<entity>:<id>`.
+- **Example:** `urn:sourceos:agent:12345`
+
+## Spec Metadata Explanation
+- **version:** The version of the schema being used.
+- **description:** A brief overview of the schema.
+
+## Validation Instructions
+To validate the agent-plane schema, use the following command:
+```bash
+jsonschema -i example.json schema.json
+```
+Make sure to replace `example.json` with your JSON data file and `schema.json` with your schema file.
+
+## Conclusion
+This documentation serves as a reference for working with Agent-Plane schemas. For further details, please refer to the additional resources provided in the repository.

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -1,39 +1,81 @@
-# Agent-Plane Schema Documentation
+# Agent Plane Schema Documentation
 
 ## Overview
-This document provides comprehensive details about the Agent-Plane schemas, including usage examples, URN patterns, spec metadata explanation, and validation instructions.
+This document provides comprehensive documentation on the Agent Plane schemas, including URN patterns, specification metadata explanation, and usage examples for key entities such as ExecutionDecision, AgentSession, and SessionReceipt.
 
-## Usage Examples
-### Example 1: Basic Usage
-```json
-{
-  "exampleKey": "exampleValue"
-}
-```
-
-### Example 2: Advanced Usage
-```json
-{
-  "advancedKey": [{
-    "nestedKey": "nestedValue"
-  }]
-}
-```
+## Schema Families Table
+| Schema Family         | Description                               |
+|-----------------------|-------------------------------------------|
+| ExecutionDecision     | Represents the decision made by the agent. |
+| AgentSession          | Represents a session of an agent.         |
+| SessionReceipt        | Represents a receipt for a session.       |
 
 ## URN Patterns
-The URN patterns for the agent-plane schemas follow the structure: `urn:example:<entity>:<id>`.
-- **Example:** `urn:sourceos:agent:12345`
+### ExecutionDecision URN
+- **Pattern**: `urn:sourceos:execution:decision:<decision_id>`
 
-## Spec Metadata Explanation
-- **version:** The version of the schema being used.
-- **description:** A brief overview of the schema.
+### AgentSession URN
+- **Pattern**: `urn:sourceos:agent:session:<session_id>`
+
+### SessionReceipt URN
+- **Pattern**: `urn:sourceos:receipt:<receipt_id>`
+
+## Schema Metadata Explanation
+Each schema includes metadata that describes its purpose, version, and last updated information.
+
+- **Version**: Indicates the version of the schema.
+- **Last Updated**: Date when the schema was last modified.
+
+## Usage Examples
+### ExecutionDecision Example
+```json
+{
+  "id": "urn:sourceos:execution:decision:12345",
+  "metadata": {
+    "version": "1.0",
+    "lastUpdated": "2026-04-05"
+  },
+  "decision": "approve"
+}
+```
+
+### AgentSession Example
+```json
+{
+  "id": "urn:sourceos:agent:session:12345",
+  "metadata": {
+    "version": "1.0",
+    "lastUpdated": "2026-04-05"
+  },
+  "status": "active"
+}
+```
+
+### SessionReceipt Example
+```json
+{
+  "id": "urn:sourceos:receipt:12345",
+  "metadata": {
+    "version": "1.0",
+    "lastUpdated": "2026-04-05"
+  },
+  "result": "success"
+}
+```
 
 ## Validation Instructions
-To validate the agent-plane schema, use the following command:
-```bash
-jsonschema -i example.json schema.json
-```
-Make sure to replace `example.json` with your JSON data file and `schema.json` with your schema file.
+Schema validation must be performed against the JSON Schema specification outlined in the [official documentation](https://json-schema.org/).
 
-## Conclusion
-This documentation serves as a reference for working with Agent-Plane schemas. For further details, please refer to the additional resources provided in the repository.
+## Versioning Discipline
+Follow semantic versioning for all schema updates:
+- Major version when incompatible API changes are made,
+- Minor version when functionality is added in a backward-compatible manner,
+- Patch version when backward-compatible bug fixes are introduced.
+
+## Current Status
+All schemas are currently under active development. All feedback is welcomed.
+
+## References
+- [JSON Schema Official Website](https://json-schema.org/)
+- SourceOS Documentation
+- API Reference links

--- a/schemas/ReleaseReceipt.json
+++ b/schemas/ReleaseReceipt.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.srcos.ai/v2/ReleaseReceipt.json",
+  "title": "ReleaseReceipt",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["id","type","specVersion","releaseTarget","verifiedAt","status"],
+  "properties": {
+    "id": {"type": "string", "pattern": "^urn:srcos:release-receipt:"},
+    "type": {"const": "ReleaseReceipt"},
+    "specVersion": {"type": "string"},
+    "releaseTarget": {"type": "string"},
+    "sourceRef": {"type": ["string","null"]},
+    "artifactHashes": {"type": "array", "items": {"type": "string"}},
+    "checks": {"type": "array", "items": {"type": "string"}},
+    "status": {"enum": ["verified","failed","partial"]},
+    "verifiedAt": {"type": "string", "format": "date-time"}
+  }
+}

--- a/schemas/RolloutPolicy.json
+++ b/schemas/RolloutPolicy.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.srcos.ai/v2/RolloutPolicy.json",
+  "title": "RolloutPolicy",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["id","type","specVersion","flagRef","rules"],
+  "properties": {
+    "id": {"type": "string", "pattern": "^urn:srcos:rollout:"},
+    "type": {"const": "RolloutPolicy"},
+    "specVersion": {"type": "string"},
+    "flagRef": {"type": "string", "pattern": "^urn:srcos:flag:"},
+    "rules": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["audience","state"],
+        "properties": {
+          "audience": {"type": "string"},
+          "state": {"enum": ["off","shadow","internal","beta","on"]},
+          "percentage": {"type": ["number","null"], "minimum": 0, "maximum": 100}
+        }
+      }
+    },
+    "notes": {"type": ["string","null"]}
+  }
+}

--- a/schemas/SessionReceipt.json
+++ b/schemas/SessionReceipt.json
@@ -1,0 +1,66 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.srcos.ai/v2/SessionReceipt.json",
+  "title": "SessionReceipt",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "id",
+    "type",
+    "specVersion",
+    "sessionRef",
+    "status",
+    "artifactRefs",
+    "decisionRefs",
+    "gateResults",
+    "capturedAt"
+  ],
+  "properties": {
+    "id": {
+      "type": "string",
+      "pattern": "^urn:srcos:receipt:session:"
+    },
+    "type": {
+      "const": "SessionReceipt"
+    },
+    "specVersion": {
+      "type": "string"
+    },
+    "sessionRef": {
+      "type": "string",
+      "pattern": "^urn:srcos:session:"
+    },
+    "status": {
+      "enum": [
+        "success",
+        "failure",
+        "paused",
+        "deferred",
+        "canceled"
+      ]
+    },
+    "artifactRefs": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "decisionRefs": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "pattern": "^urn:srcos:exec-decision:"
+      }
+    },
+    "gateResults": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "capturedAt": {
+      "type": "string",
+      "format": "date-time"
+    }
+  }
+}

--- a/schemas/SessionReview.json
+++ b/schemas/SessionReview.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.srcos.ai/v2/SessionReview.json",
+  "title": "SessionReview",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "id",
+    "type",
+    "specVersion",
+    "sessionRef",
+    "summaryRef",
+    "learnedMemoryRefs",
+    "reviewedAt"
+  ],
+  "properties": {
+    "id": {"type": "string", "pattern": "^urn:srcos:session-review:"},
+    "type": {"const": "SessionReview"},
+    "specVersion": {"type": "string"},
+    "sessionRef": {"type": "string", "pattern": "^urn:srcos:session:"},
+    "summaryRef": {"type": "string"},
+    "learnedMemoryRefs": {"type": "array", "items": {"type": "string", "pattern": "^urn:srcos:memory:"}},
+    "followupRefs": {"type": "array", "items": {"type": "string"}},
+    "reviewedAt": {"type": "string", "format": "date-time"}
+  }
+}

--- a/schemas/SkillManifest.json
+++ b/schemas/SkillManifest.json
@@ -1,0 +1,125 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.srcos.ai/v2/SkillManifest.json",
+  "title": "SkillManifest",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "id",
+    "type",
+    "specVersion",
+    "name",
+    "version",
+    "entryDoc",
+    "description",
+    "activationRules",
+    "requires",
+    "policyBindings",
+    "artifactOutputs",
+    "reviewMode",
+    "allowShellExecution"
+  ],
+  "properties": {
+    "id": {
+      "type": "string",
+      "pattern": "^urn:srcos:skill:"
+    },
+    "type": {
+      "const": "SkillManifest"
+    },
+    "specVersion": {
+      "type": "string"
+    },
+    "name": {
+      "type": "string"
+    },
+    "version": {
+      "type": "string"
+    },
+    "entryDoc": {
+      "type": "string"
+    },
+    "description": {
+      "type": "string"
+    },
+    "activationRules": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "commands": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "filePatterns": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "intentTags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "requires": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "binaries": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "anyBins": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "tools": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "executionSurfaceRef": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "pattern": "^urn:srcos:surface:"
+    },
+    "policyBindings": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "artifactOutputs": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "reviewMode": {
+      "type": "boolean"
+    },
+    "allowShellExecution": {
+      "type": "boolean"
+    },
+    "protectedPaths": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
+  }
+}

--- a/schemas/TelemetryEvent.json
+++ b/schemas/TelemetryEvent.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.srcos.ai/v2/TelemetryEvent.json",
+  "title": "TelemetryEvent",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["id","type","specVersion","sessionRef","eventType","capturedAt"],
+  "properties": {
+    "id": {"type": "string", "pattern": "^urn:srcos:telemetry:"},
+    "type": {"const": "TelemetryEvent"},
+    "specVersion": {"type": "string"},
+    "sessionRef": {"type": "string", "pattern": "^urn:srcos:session:"},
+    "eventType": {"type": "string"},
+    "severity": {"enum": ["debug","info","warn","error"]},
+    "capturedAt": {"type": "string", "format": "date-time"}
+  }
+}


### PR DESCRIPTION
## What this lands

This draft PR adds the first six core agent-plane schema scaffolds:
- `ExecutionDecision.json`
- `AgentSession.json`
- `ExecutionSurface.json`
- `SkillManifest.json`
- `MemoryEntry.json`
- `SessionReceipt.json`

## Why now

The current public `sourceos-spec` surface is strong on metadata / governance / batch-run objects, but it does not yet name the core runtime law needed by the agent plane. These scaffolds are the smallest clean-room patch that starts to close that gap without overloading existing data-plane objects such as `CapabilityToken`, `PolicyDecision`, `WorkloadSpec`, or `RunRecord`.

## Non-goals in this PR

This draft does **not** yet:
- patch `openapi.yaml`
- patch `asyncapi.yaml`
- add tool/session/promotion/reversal artifacts
- add the second-wave leak-derived objects (`SessionReview`, `ExperimentFlag`, `RolloutPolicy`, `TelemetryEvent`, `FrustrationSignal`, `ReleaseReceipt`)

## Follow-up queue

1. Wire the new schema family into OpenAPI / AsyncAPI.
2. Patch `SociOS-Linux/agentos-starter` interfaces (`MemoryAPI`, `Orchestrator`, `Executor`).
3. Extend `SocioProphet/agentplane` bundle / artifact schemas.
4. Add validator/admission wiring in `SociOS-Linux/imagelab`.
5. Normalize `SourceOS-Linux/openclaw` runtime surfaces against these contracts.

## Clean-room posture

This work is based on public repo surfaces and public reporting about Claude Code’s leak-era lessons. It does not copy proprietary Anthropic implementation details.
