### PR TITLE
Add merge-conflict marker checks to PR template and contributing guide

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -24,6 +24,7 @@
 - [ ] `specVersion` bumped if this is a breaking change
 - [ ] ADR created in `docs/adr/` if the design involves a non-obvious choice
 - [ ] `semantic/context.jsonld` and `hydra.jsonld` updated for new first-class types
+- [ ] No Git merge conflict markers remain in touched files
 
 ## Validation commands run
 
@@ -36,6 +37,9 @@ spectral lint openapi.yaml
 
 # AsyncAPI lint
 asyncapi validate asyncapi.yaml
+
+# Merge-conflict marker check
+rg -n '^(<{7}|={7}|>{7})' .github/PULL_REQUEST_TEMPLATE.md CHANGELOG.md CONTRIBUTING.md README.md asyncapi.agent-plane.patch.yaml asyncapi.yaml examples/community.json examples/rating.json openapi.agent-plane.patch.yaml openapi.yaml schemas/AgentSession.json schemas/Agreement.json schemas/AuthorityLink.json schemas/CapabilityToken.json schemas/Comment.json schemas/Community.json schemas/Connector.json schemas/DataRef.json schemas/DataSphere.json schemas/Dataset.json schemas/EntityField.json schemas/EventEnvelope.json schemas/Exception.json schemas/ExecutionDecision.json schemas/ExecutionSurface.json
 ```
 
 ## Related issues / ADRs

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -156,6 +156,7 @@ Validate before committing:
 ```bash
 spectral lint openapi.yaml
 asyncapi validate asyncapi.yaml
+rg -n '^(<{7}|={7}|>{7})' .github/PULL_REQUEST_TEMPLATE.md CHANGELOG.md CONTRIBUTING.md README.md asyncapi.agent-plane.patch.yaml asyncapi.yaml examples/community.json examples/rating.json openapi.agent-plane.patch.yaml openapi.yaml schemas/AgentSession.json schemas/Agreement.json schemas/AuthorityLink.json schemas/CapabilityToken.json schemas/Comment.json schemas/Community.json schemas/Connector.json schemas/DataRef.json schemas/DataSphere.json schemas/Dataset.json schemas/EntityField.json schemas/EventEnvelope.json schemas/Exception.json schemas/ExecutionDecision.json schemas/ExecutionSurface.json
 ```
 
 ---
@@ -188,6 +189,7 @@ The PR template will remind you, but here is the complete list:
 - [ ] ADR created in `docs/adr/` if design rationale is non-obvious
 - [ ] `semantic/context.jsonld` and `hydra.jsonld` updated for first-class types
 - [ ] `specVersion` bumped if required (see [Breaking vs additive changes](#breaking-vs-additive-changes))
+- [ ] No Git merge conflict markers remain in touched files
 
 ---
 


### PR DESCRIPTION
### Motivation

- Prevent accidental inclusion of Git merge conflict markers in files touched by a PR. 
- Make it easy for contributors to run an automated check for conflict markers as part of local validation and PR review.

### Description

- Add a new checklist item `No Git merge conflict markers remain in touched files` to `.github/PULL_REQUEST_TEMPLATE.md` and `CONTRIBUTING.md`.
- Add a `rg` (ripgrep) command to the `Validation commands run` section in `.github/PULL_REQUEST_TEMPLATE.md` to search for conflict markers (`<<<<<<<`, `=======`, `>>>>>>>`) across a set of important files.
- Add the same `rg` command to the `Validate before committing` section in `CONTRIBUTING.md` so contributors can run the check locally before pushing.
- Minor formatting and spacing adjustments around the added commands and checklist entries.

### Testing

- No automated test suite was executed for this documentation-only change. 
- The change is additive to developer tooling and linters and does not affect production code or schema validation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6a28a20fc832393f8ecdcf44164b7)