### PR TITLE
Add merge-conflict marker check to PR template and contributing guide

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -24,6 +24,7 @@
 - [ ] `specVersion` bumped if this is a breaking change
 - [ ] ADR created in `docs/adr/` if the design involves a non-obvious choice
 - [ ] `semantic/context.jsonld` and `hydra.jsonld` updated for new first-class types
+- [ ] No Git merge conflict markers remain in touched files
 
 ## Validation commands run
 
@@ -36,6 +37,9 @@ spectral lint openapi.yaml
 
 # AsyncAPI lint
 asyncapi validate asyncapi.yaml
+
+# Merge-conflict marker check
+git grep -nE '^(<{7}|={7}|>{7})' -- .
 ```
 
 ## Related issues / ADRs

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -156,6 +156,7 @@ Validate before committing:
 ```bash
 spectral lint openapi.yaml
 asyncapi validate asyncapi.yaml
+git grep -nE '^(<{7}|={7}|>{7})' -- .
 ```
 
 ---
@@ -188,6 +189,7 @@ The PR template will remind you, but here is the complete list:
 - [ ] ADR created in `docs/adr/` if design rationale is non-obvious
 - [ ] `semantic/context.jsonld` and `hydra.jsonld` updated for first-class types
 - [ ] `specVersion` bumped if required (see [Breaking vs additive changes](#breaking-vs-additive-changes))
+- [ ] No Git merge conflict markers remain in touched files
 
 ---
 


### PR DESCRIPTION
### Motivation
- Ensure PR authors and contributors run a simple check to catch leftover Git merge conflict markers before committing or opening a PR.

### Description
- Added a checklist item and a repository check command for merge-conflict markers to `.github/PULL_REQUEST_TEMPLATE.md` and `CONTRIBUTING.md` by inserting `- [ ] No Git merge conflict markers remain in touched files` and the `git grep -nE '^(<{7}|={7}|>{7})' -- .` validation step into the validation commands section.

### Testing
- Ran the new merge-conflict check `git grep -nE '^(<{7}|={7}|>{7})' -- .` against the repository and it returned no matches, indicating no leftover conflict markers were present.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6a28a20fc832393f8ecdcf44164b7)