### PR TITLE
chore: document merge-to-main conflict reconciliation in CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ This file follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) conve
 - `.github/PULL_REQUEST_TEMPLATE.md` proper PR template.
 
 ### Changed
+- Reconciled long-lived branch drift across documentation, API contracts, examples, and schema artifacts to unblock merge-to-`main` conflict resolution (no contract-level semantic changes).
 - `openapi.yaml` — added `info.description`, `info.contact`, `info.license`, `components/responses` (BadRequest, Unauthorized, Forbidden, NotFound, InternalServerError), `GET` and `DELETE` operations for all resources, operation `summary` and `description` strings, and 4xx/5xx responses on all endpoints.
 - `openapi.agent-plane.patch.yaml` — added operation summaries, descriptions, `GET` operations for sessions, skills, and memory, and error responses.
 - `asyncapi.yaml` — added `info.description`, `info.contact`, `info.license`, `subscribe` directions for all channels, channel `description` and `operationId` values, and five new channels for `agreement`, `connector`, `provenance`, `schema`, and `token` events.


### PR DESCRIPTION
### Motivation
- Document that long-lived branch drift across documentation, API contracts, examples, and schema artifacts was reconciled to unblock merging to `main` without making contract-level semantic changes.

### Description
- Add a short Unreleased entry to `CHANGELOG.md` noting the reconciliation and commit the update to branch `work` (modified file: `CHANGELOG.md`).

### Testing
- Ran `git diff -- CHANGELOG.md` to verify the insertion and `git status --short --branch` to confirm the commit state, and both commands succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6b57bdab48323a49066ebc92882b2)