### PR TITLE
spec: add incident event schema + truth/delta surface examples

### DIFF
--- a/examples/control-plane/incident.freeze.sample.json
+++ b/examples/control-plane/incident.freeze.sample.json
@@ -1,0 +1,34 @@
+{
+  "event_id": "evt_01JQ3INCIDENTFREEZE0001",
+  "event_name": "incident.freeze",
+  "occurred_at": "2026-04-14T21:37:00Z",
+  "actor": {
+    "kind": "service",
+    "id": "sourceos-incident"
+  },
+  "run": {
+    "run_id": "run_01JQ3INCIDENT0001",
+    "trace_id": "trace_freeze_0001",
+    "span_id": "span_freeze_0001",
+    "attempt": 1
+  },
+  "coordinates": {
+    "env": "local",
+    "topology_scope": "host",
+    "trust_class": "sealed",
+    "tenant_scope": "default",
+    "data_sensitivity": "redacted"
+  },
+  "status": "succeeded",
+  "refs": {
+    "truth_surface_ref": "urn:srcos:truth-surface:ts_0001",
+    "delta_surface_ref": "urn:srcos:delta-surface:ds_0001",
+    "evidence_bundle_ref": "artifact://evidence/incident/run_01JQ3INCIDENT0001",
+    "cairn_before_ref": "cairn://incident/freeze/before/0001",
+    "cairn_after_ref": "cairn://incident/freeze/after/0001"
+  },
+  "payload": {
+    "actions": ["block_frontier_egress", "snapshot_runtime_truth", "pause_high_risk_units"],
+    "notes": "Freeze phase succeeded; mutation halted; snapshots captured."
+  }
+}

--- a/examples/delta-surface.sample.json
+++ b/examples/delta-surface.sample.json
@@ -1,0 +1,41 @@
+{
+  "id": "urn:srcos:delta-surface:ds_0001",
+  "type": "DeltaSurface",
+  "specVersion": "2.0.0",
+  "fromRef": "urn:srcos:truth-surface:ts_0000",
+  "toRef": "urn:srcos:truth-surface:ts_0001",
+  "createdAt": "2026-04-14T21:36:00Z",
+  "merkleRoot": "sha256:REPLACE_ME",
+  "signer": "sourceos-delta-surface",
+  "signature": "sig:REPLACE_ME",
+  "metrics": {
+    "semantic": {
+      "topic_alignment_cosine": 0.91,
+      "feature_jaccard": 0.84
+    },
+    "runtime": {
+      "new_processes": 2,
+      "namespace_transitions": 0
+    },
+    "governance": {
+      "new_policy_decisions": 1
+    }
+  },
+  "gate": {
+    "status": "needs_more_evidence",
+    "riskScore": 12,
+    "riskThreshold": 30,
+    "humanApprovalRequired": false,
+    "humanApproved": false,
+    "evidenceRequired": ["logs", "traces", "metrics", "policy_decision"],
+    "evidencePresent": ["logs", "policy_decision"],
+    "evidenceMissing": ["traces", "metrics"],
+    "reasons": ["missing required evidence: traces", "missing required evidence: metrics"]
+  },
+  "refs": {
+    "policyDecisionRefs": ["urn:srcos:decision:aa11bb22"],
+    "evidenceBundleRef": "artifact://evidence/run_77cc88dd",
+    "cairnBeforeRef": "cairn://system/sealed/before/ts_0000",
+    "cairnAfterRef": "cairn://system/sealed/after/ts_0001"
+  }
+}

--- a/examples/truth-surface.sample.json
+++ b/examples/truth-surface.sample.json
@@ -1,0 +1,45 @@
+{
+  "id": "urn:srcos:truth-surface:ts_0001",
+  "type": "TruthSurface",
+  "specVersion": "2.0.0",
+  "plane": "system.sealed",
+  "createdAt": "2026-04-14T21:35:00Z",
+  "merkleRoot": "sha256:REPLACE_ME",
+  "signer": "sourceos-truth-surface",
+  "signature": "sig:REPLACE_ME",
+  "refs": {
+    "policyDecisionRefs": ["urn:srcos:decision:aa11bb22"],
+    "capabilityTokenIds": ["tok_123"],
+    "runRecordRefs": ["urn:srcos:run:77cc88dd"],
+    "provenanceRefs": ["urn:srcos:prov:001"],
+    "telemetryRefs": ["urn:srcos:telemetry:t001"],
+    "evidenceBundleRefs": ["artifact://evidence/run_77cc88dd"],
+    "cairnBeforeRef": "cairn://system/sealed/before/ts_0000",
+    "cairnAfterRef": "cairn://system/sealed/after/ts_0001"
+  },
+  "evidence": {
+    "required": ["logs", "traces", "metrics", "policy_decision"],
+    "present": ["logs", "policy_decision"],
+    "missing": ["traces", "metrics"]
+  },
+  "semantics": {
+    "anchors": ["B1", "B4"],
+    "glossary": ["urn:srcos:glossary:dob"],
+    "topics": ["boot.integrity", "policy.posture"]
+  },
+  "runtime": {
+    "integrity": {
+      "measuredBoot": "ok",
+      "ima": "enabled"
+    },
+    "processSummary": {
+      "processCount": 243,
+      "suspicious": 0
+    }
+  },
+  "governance": {
+    "policyPackDigest": "sha256:REPLACE_ME",
+    "riskScore": 12,
+    "humanApprovalRequired": false
+  }
+}

--- a/schemas/control-plane/incident-events.schema.json
+++ b/schemas/control-plane/incident-events.schema.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.org/schemas/events/incident-events.schema.json",
+  "title": "IncidentEvent",
+  "description": "Control-plane incident lifecycle events (Freeze/Fork/Kill). Uses the same actor/run/refs/payload conventions as other control-plane lifecycle events.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["event_id", "event_name", "occurred_at", "actor", "status"],
+  "properties": {
+    "event_id": { "type": "string", "minLength": 1 },
+    "event_name": {
+      "type": "string",
+      "enum": ["incident.freeze", "incident.fork", "incident.kill"]
+    },
+    "occurred_at": { "type": "string", "format": "date-time" },
+    "actor": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["kind", "id"],
+      "properties": {
+        "kind": { "type": "string", "enum": ["human", "agent", "service", "scheduler"] },
+        "id": { "type": "string", "minLength": 1 }
+      }
+    },
+    "run": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "run_id": { "type": "string", "minLength": 1 },
+        "trace_id": { "type": "string" },
+        "span_id": { "type": "string" },
+        "attempt": { "type": "integer", "minimum": 1 }
+      }
+    },
+    "coordinates": { "type": "object", "additionalProperties": true },
+    "status": {
+      "type": "string",
+      "enum": ["requested", "running", "succeeded", "failed", "denied", "archived"],
+      "description": "Status progression for the incident action."
+    },
+    "refs": { "type": "object", "additionalProperties": true },
+    "payload": { "type": "object", "additionalProperties": true }
+  }
+}


### PR DESCRIPTION
Adds missing v0 portability artifacts referenced by ADR-0001 Appendix A:

- schemas/control-plane/incident-events.schema.json
- examples/truth-surface.sample.json
- examples/delta-surface.sample.json
- examples/control-plane/incident.freeze.sample.json

These are additive-only and do not modify existing schemas.
