### PR TITLE
schemas: add control node, Node Commander, promotion gate, and build evidence starters

### DIFF
--- a/examples/build_validation_evidence_bundle.json
+++ b/examples/build_validation_evidence_bundle.json
@@ -1,0 +1,27 @@
+{
+  "id": "urn:srcos:build-evidence:sourceos-workstation-v0-2026-04-15",
+  "type": "BuildValidationEvidenceBundle",
+  "specVersion": "2.0.0",
+  "buildRef": "urn:srcos:build:sourceos-workstation-v0-2026-04-15",
+  "profileRef": "urn:srcos:control-node:macbook-air-operator-01",
+  "artifactRefs": [
+    "urn:agentplane:artifact:validation:bundle-sourceos-workstation-v0-2026-04-15",
+    "urn:agentplane:artifact:run:sourceos-workstation-v0-2026-04-15",
+    "urn:agentplane:artifact:replay:sourceos-workstation-v0-2026-04-15"
+  ],
+  "scenarioResults": [
+    {
+      "scenarioId": "sourceos.first_boot.dev_init.v1",
+      "status": "passed",
+      "artifactRef": "urn:agentplane:artifact:validation:sourceos.first_boot.dev_init.v1"
+    },
+    {
+      "scenarioId": "node-commander.local.bootstrap.v0",
+      "status": "passed",
+      "artifactRef": "urn:agentplane:artifact:run:node-commander.local.bootstrap.v0"
+    }
+  ],
+  "promotionGateRef": "urn:srcos:image-gate:sourceos-workstation-v0-dev",
+  "replayRef": "urn:agentplane:artifact:replay:sourceos-workstation-v0-2026-04-15",
+  "issuedAt": "2026-04-15T22:45:00Z"
+}

--- a/examples/control_node_profile.json
+++ b/examples/control_node_profile.json
@@ -1,0 +1,20 @@
+{
+  "id": "urn:srcos:control-node:macbook-air-operator-01",
+  "type": "ControlNodeProfile",
+  "specVersion": "2.0.0",
+  "hostRole": "operator-control-node",
+  "hostPlatform": "aarch64-darwin",
+  "containerRuntime": "podman",
+  "nodeCommanderRuntimeRef": "urn:srcos:node-commander:runtime:macbook-air-operator-01",
+  "placementOrder": [
+    "local",
+    "trusted-private",
+    "attested-fog",
+    "burst-cloud"
+  ],
+  "workspace": {
+    "configDir": "/etc/node-commander",
+    "stateDir": "/var/lib/node-commander",
+    "evidenceDir": "/var/lib/node-commander/evidence"
+  }
+}

--- a/examples/image_promotion_gate.json
+++ b/examples/image_promotion_gate.json
@@ -1,0 +1,30 @@
+{
+  "id": "urn:srcos:image-gate:sourceos-workstation-v0-dev",
+  "type": "ImagePromotionGate",
+  "specVersion": "2.0.0",
+  "candidateBuildRef": "urn:srcos:build:sourceos-workstation-v0-2026-04-15",
+  "profileRef": "urn:srcos:control-node:macbook-air-operator-01",
+  "requiredArtifacts": [
+    "validation-artifact.json",
+    "run-artifact.json",
+    "replay-artifact.json"
+  ],
+  "requiredChecks": [
+    "static-validation",
+    "scenario-pass",
+    "promotion-evidence-complete"
+  ],
+  "decision": "approved",
+  "reasonCodes": [
+    "all-required-checks-passed"
+  ],
+  "gitUpdate": {
+    "allowed": true,
+    "targetRepo": "SociOS-Linux/source-os",
+    "targetRef": "main"
+  },
+  "taskCompletion": {
+    "allowed": true,
+    "issueRef": "issue://source-os/workstation-v0-bootstrap"
+  }
+}

--- a/examples/node_commander_runtime.json
+++ b/examples/node_commander_runtime.json
@@ -1,0 +1,21 @@
+{
+  "id": "urn:srcos:node-commander:runtime:macbook-air-operator-01",
+  "type": "NodeCommanderRuntime",
+  "specVersion": "2.0.0",
+  "runtimeMode": "bootstrap",
+  "packaging": {
+    "kind": "oci-image",
+    "imageRef": "us-central1-docker.pkg.dev/socioprophet-web/node-commander/node-commander:dev-boot",
+    "entrypoint": "podman --connection podman-machine-default run --pull=never --rm --replace --name node-commander <image>"
+  },
+  "execution": {
+    "scope": "user",
+    "serviceManager": "launchd",
+    "rootless": true
+  },
+  "config": {
+    "configDir": "/etc/node-commander",
+    "stateDir": "/var/lib/node-commander",
+    "logDestination": "/tmp/node-commander.log"
+  }
+}

--- a/schemas/BuildValidationEvidenceBundle.json
+++ b/schemas/BuildValidationEvidenceBundle.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.srcos.ai/v2/BuildValidationEvidenceBundle.json",
+  "title": "BuildValidationEvidenceBundle",
+  "description": "Evidence bundle tying build identity, scenario outcomes, and promotion references together for image validation.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["id", "type", "specVersion", "buildRef", "profileRef", "artifactRefs", "scenarioResults", "issuedAt"],
+  "properties": {
+    "id": { "type": "string", "pattern": "^urn:srcos:build-evidence:" },
+    "type": { "const": "BuildValidationEvidenceBundle" },
+    "specVersion": { "type": "string" },
+    "buildRef": { "type": "string" },
+    "profileRef": { "type": "string", "pattern": "^urn:srcos:control-node:" },
+    "artifactRefs": { "type": "array", "items": { "type": "string" } },
+    "scenarioResults": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["scenarioId", "status", "artifactRef"],
+        "properties": {
+          "scenarioId": { "type": "string" },
+          "status": { "enum": ["passed", "failed", "skipped"] },
+          "artifactRef": { "type": "string" }
+        }
+      }
+    },
+    "promotionGateRef": { "type": ["string", "null"], "pattern": "^urn:srcos:image-gate:" },
+    "replayRef": { "type": ["string", "null"] },
+    "issuedAt": { "type": "string", "format": "date-time" }
+  }
+}

--- a/schemas/ControlNodeProfile.json
+++ b/schemas/ControlNodeProfile.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.srcos.ai/v2/ControlNodeProfile.json",
+  "title": "ControlNodeProfile",
+  "description": "Typed profile for an operator-side local-first control node.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["id", "type", "specVersion", "hostRole", "hostPlatform", "containerRuntime", "placementOrder", "workspace"],
+  "properties": {
+    "id": { "type": "string", "pattern": "^urn:srcos:control-node:" },
+    "type": { "const": "ControlNodeProfile" },
+    "specVersion": { "type": "string" },
+    "hostRole": { "enum": ["operator-control-node"] },
+    "hostPlatform": { "type": "string" },
+    "containerRuntime": { "enum": ["podman"] },
+    "nodeCommanderRuntimeRef": { "type": ["string", "null"], "pattern": "^urn:srcos:node-commander:" },
+    "placementOrder": {
+      "type": "array",
+      "items": { "enum": ["local", "trusted-private", "attested-fog", "burst-cloud"] },
+      "minItems": 1
+    },
+    "workspace": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["configDir", "stateDir", "evidenceDir"],
+      "properties": {
+        "configDir": { "type": "string" },
+        "stateDir": { "type": "string" },
+        "evidenceDir": { "type": "string" }
+      }
+    }
+  }
+}

--- a/schemas/ImagePromotionGate.json
+++ b/schemas/ImagePromotionGate.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.srcos.ai/v2/ImagePromotionGate.json",
+  "title": "ImagePromotionGate",
+  "description": "Promotion decision envelope for whether a candidate image may update a Git repository and mark a task complete.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["id", "type", "specVersion", "candidateBuildRef", "profileRef", "requiredArtifacts", "requiredChecks", "decision", "gitUpdate", "taskCompletion"],
+  "properties": {
+    "id": { "type": "string", "pattern": "^urn:srcos:image-gate:" },
+    "type": { "const": "ImagePromotionGate" },
+    "specVersion": { "type": "string" },
+    "candidateBuildRef": { "type": "string" },
+    "profileRef": { "type": "string", "pattern": "^urn:srcos:control-node:" },
+    "requiredArtifacts": { "type": "array", "items": { "type": "string" } },
+    "requiredChecks": { "type": "array", "items": { "type": "string" } },
+    "decision": { "enum": ["pending", "approved", "denied", "waived"] },
+    "reasonCodes": { "type": "array", "items": { "type": "string" } },
+    "gitUpdate": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["allowed"],
+      "properties": {
+        "allowed": { "type": "boolean" },
+        "targetRepo": { "type": ["string", "null"] },
+        "targetRef": { "type": ["string", "null"] }
+      }
+    },
+    "taskCompletion": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["allowed"],
+      "properties": {
+        "allowed": { "type": "boolean" },
+        "issueRef": { "type": ["string", "null"] }
+      }
+    }
+  }
+}

--- a/schemas/NodeCommanderRuntime.json
+++ b/schemas/NodeCommanderRuntime.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.srcos.ai/v2/NodeCommanderRuntime.json",
+  "title": "NodeCommanderRuntime",
+  "description": "Typed runtime descriptor for a Node Commander deployment envelope.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["id", "type", "specVersion", "runtimeMode", "packaging", "execution", "config"],
+  "properties": {
+    "id": { "type": "string", "pattern": "^urn:srcos:node-commander:" },
+    "type": { "const": "NodeCommanderRuntime" },
+    "specVersion": { "type": "string" },
+    "runtimeMode": { "enum": ["bootstrap", "service"] },
+    "packaging": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind"],
+      "properties": {
+        "kind": { "enum": ["oci-image", "local-binary"] },
+        "imageRef": { "type": ["string", "null"] },
+        "entrypoint": { "type": ["string", "null"] }
+      }
+    },
+    "execution": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["scope", "serviceManager", "rootless"],
+      "properties": {
+        "scope": { "enum": ["user", "system"] },
+        "serviceManager": { "enum": ["launchd", "systemd"] },
+        "rootless": { "type": "boolean" }
+      }
+    },
+    "config": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["configDir", "stateDir", "logDestination"],
+      "properties": {
+        "configDir": { "type": "string" },
+        "stateDir": { "type": "string" },
+        "logDestination": { "type": "string" }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Add the first machine-readable starter slice for the local-first control-node and image-promotion seam.

Included:
- `schemas/ControlNodeProfile.json`
- `schemas/NodeCommanderRuntime.json`
- `schemas/ImagePromotionGate.json`
- `schemas/BuildValidationEvidenceBundle.json`
- matching example payloads under `examples/`

This is additive and keeps the first slice narrow.