### PR TITLE
control-plane: canonical srcos $id wrappers for legacy schemas

### DIFF
--- a/schemas/control-plane/BootReleaseSet.json
+++ b/schemas/control-plane/BootReleaseSet.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.srcos.ai/v2/control-plane/BootReleaseSet.json",
+  "title": "BootReleaseSet",
+  "description": "Canonical BootReleaseSet schema. Wrapper that preserves legacy identifier while providing a stable srcos namespace for new references.",
+  "allOf": [
+    { "$ref": "./boot-release-set.schema.json" }
+  ]
+}

--- a/schemas/control-plane/EnrollmentToken.json
+++ b/schemas/control-plane/EnrollmentToken.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.srcos.ai/v2/control-plane/EnrollmentToken.json",
+  "title": "EnrollmentToken",
+  "description": "Canonical EnrollmentToken schema. Wrapper that preserves legacy identifier while providing a stable srcos namespace for new references.",
+  "allOf": [
+    { "$ref": "./enrollment-token.schema.json" }
+  ]
+}

--- a/schemas/control-plane/ExperienceProfile.json
+++ b/schemas/control-plane/ExperienceProfile.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.srcos.ai/v2/control-plane/ExperienceProfile.json",
+  "title": "ExperienceProfile",
+  "description": "Canonical ExperienceProfile schema. Wrapper that preserves legacy identifier while providing a stable srcos namespace for new references.",
+  "allOf": [
+    { "$ref": "./experience-profile.schema.json" }
+  ]
+}

--- a/schemas/control-plane/Fingerprint.json
+++ b/schemas/control-plane/Fingerprint.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.srcos.ai/v2/control-plane/Fingerprint.json",
+  "title": "Fingerprint",
+  "description": "Canonical Fingerprint schema. Wrapper that preserves legacy identifier while providing a stable srcos namespace for new references.",
+  "allOf": [
+    { "$ref": "./fingerprint.schema.json" }
+  ]
+}

--- a/schemas/control-plane/IncidentEvent.json
+++ b/schemas/control-plane/IncidentEvent.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.srcos.ai/v2/control-plane/IncidentEvent.json",
+  "title": "IncidentEvent",
+  "description": "Canonical IncidentEvent schema. Wrapper retained for consistency (the underlying incident-events.schema.json is already normalized into srcos namespace).",
+  "allOf": [
+    { "$ref": "./incident-events.schema.json" }
+  ]
+}

--- a/schemas/control-plane/IsolationProfile.json
+++ b/schemas/control-plane/IsolationProfile.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.srcos.ai/v2/control-plane/IsolationProfile.json",
+  "title": "IsolationProfile",
+  "description": "Canonical IsolationProfile schema. Wrapper that preserves legacy identifier while providing a stable srcos namespace for new references.",
+  "allOf": [
+    { "$ref": "./isolation-profile.schema.json" }
+  ]
+}

--- a/schemas/control-plane/MeshSkill.json
+++ b/schemas/control-plane/MeshSkill.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.srcos.ai/v2/control-plane/MeshSkill.json",
+  "title": "MeshSkill",
+  "description": "Canonical MeshSkill schema. Wrapper that preserves legacy identifier while providing a stable srcos namespace for new references.",
+  "allOf": [
+    { "$ref": "./mesh-skill.schema.json" }
+  ]
+}

--- a/schemas/control-plane/README.md
+++ b/schemas/control-plane/README.md
@@ -2,7 +2,22 @@
 
 This directory contains the first machine-readable contract family for the local-first SourceOS lifecycle slice.
 
+## Canonical schema identity
+
+This tranche was originally imported with `$id` values under the `socioprophet.org` namespace (legacy).
+
+Canonical SourceOS contract IDs use the `schemas.srcos.ai/v2/...` namespace.
+
+To avoid breaking legacy `$id` consumers, this directory now supports a **two-layer identity model**:
+
+- **Legacy schemas**: `*.schema.json` files preserve the original `$id` values.
+- **Canonical wrappers**: `*.json` files provide canonical `$id` values in the `schemas.srcos.ai` namespace and `allOf`-wrap the legacy schema.
+
+New work should reference the canonical wrapper filenames.
+
 ## Included schemas
+
+Legacy (original import, legacy `$id`):
 
 - `experience-profile.schema.json`
 - `isolation-profile.schema.json`
@@ -10,7 +25,24 @@ This directory contains the first machine-readable contract family for the local
 - `boot-release-set.schema.json`
 - `enrollment-token.schema.json`
 - `fingerprint.schema.json`
-- `incident-events.schema.json` (existing)
+- `mesh-skill.schema.json`
+- `skill-execution-events.schema.json`
+
+Canonical wrappers (preferred for new references):
+
+- `ExperienceProfile.json`
+- `IsolationProfile.json`
+- `ReleaseSet.json`
+- `BootReleaseSet.json`
+- `EnrollmentToken.json`
+- `Fingerprint.json`
+- `MeshSkill.json`
+- `SkillExecutionEvent.json`
+- `IncidentEvent.json`
+
+Incident schema:
+
+- `incident-events.schema.json` (normalized to `schemas.srcos.ai` by PR #35)
 
 ## Intent
 

--- a/schemas/control-plane/ReleaseSet.json
+++ b/schemas/control-plane/ReleaseSet.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.srcos.ai/v2/control-plane/ReleaseSet.json",
+  "title": "ReleaseSet",
+  "description": "Canonical ReleaseSet schema. Wrapper that preserves legacy identifier while providing a stable srcos namespace for new references.",
+  "allOf": [
+    { "$ref": "./release-set.schema.json" }
+  ]
+}

--- a/schemas/control-plane/SkillExecutionEvent.json
+++ b/schemas/control-plane/SkillExecutionEvent.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.srcos.ai/v2/control-plane/SkillExecutionEvent.json",
+  "title": "SkillExecutionEvent",
+  "description": "Canonical SkillExecutionEvent schema. This is a wrapper that preserves legacy identifiers while providing a stable srcos namespace for new references.",
+  "allOf": [
+    { "$ref": "./skill-execution-events.schema.json" }
+  ]
+}


### PR DESCRIPTION
This PR eliminates multi-authority schema identity in the control-plane tranche without breaking legacy consumers.

Problem:
- Most control-plane schemas were imported with `$id` under `socioprophet.org`, while the canonical SourceOS typed-contract namespace is `schemas.srcos.ai/v2/...`.
- PR #35 normalized IncidentEvent into srcos namespace, creating an inconsistent mix.

Approach (no loss of intent):
1) Keep legacy schemas stable
- Preserve existing `*.schema.json` files and their legacy `$id` values.

2) Add canonical wrappers
- Add `*.json` wrapper schemas with canonical `$id` under `https://schemas.srcos.ai/v2/control-plane/<Type>.json`.
- Each wrapper uses `allOf` with a single `$ref` to the legacy schema.

3) Document the policy
- Update `schemas/control-plane/README.md` to define the two-layer identity model and list canonical wrapper filenames.

Wrappers added:
- ExperienceProfile.json
- IsolationProfile.json
- ReleaseSet.json
- BootReleaseSet.json
- EnrollmentToken.json
- Fingerprint.json
- MeshSkill.json
- SkillExecutionEvent.json
- IncidentEvent.json

Notes:
- Legacy refs continue to work.
- New work should reference canonical wrappers.
- A future major/minor may fully normalize legacy `$id` values once downstream consumers migrate.
