### PR TITLE
spec hygiene: eliminate duplicate IncidentEvent $id and reference canonical wrapper

### DIFF
--- a/openapi.truth-plane.patch.yaml
+++ b/openapi.truth-plane.patch.yaml
@@ -63,7 +63,7 @@ paths:
         required: true
         content:
           application/json:
-            schema: { $ref: './schemas/control-plane/incident-events.schema.json' }
+            schema: { $ref: './schemas/control-plane/IncidentEvent.json' }
       responses:
         '200':
           description: IncidentEvent recorded successfully.

--- a/schemas/control-plane/incident-events.schema.json
+++ b/schemas/control-plane/incident-events.schema.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://schemas.srcos.ai/v2/control-plane/IncidentEvent.json",
+  "$id": "https://socioprophet.org/schemas/events/incident-events.schema.json",
   "title": "IncidentEvent",
-  "description": "Control-plane incident lifecycle events (Freeze/Fork/Kill). Uses the same actor/run/refs/payload conventions as other control-plane lifecycle events.",
+  "description": "Control-plane incident lifecycle events (Freeze/Fork/Kill). Legacy schema identity; prefer schemas/control-plane/IncidentEvent.json for canonical srcos $id.",
   "type": "object",
   "additionalProperties": false,
   "required": ["event_id", "event_name", "occurred_at", "actor", "status"],


### PR DESCRIPTION
Fixes a subtle multi-authority issue introduced by PR #35/#38:

- Both `schemas/control-plane/incident-events.schema.json` and `schemas/control-plane/IncidentEvent.json` currently share the same canonical `$id`.
  This creates duplicate schema identity and can confuse resolvers.

This PR restores the intended two-layer model:

1) Make `incident-events.schema.json` a legacy schema identity
- Reverts its `$id` to the legacy `socioprophet.org` namespace.
- Keeps its content and title unchanged.

2) Keep `IncidentEvent.json` as the canonical identity
- Canonical `$id` remains `https://schemas.srcos.ai/v2/control-plane/IncidentEvent.json`.

3) Update Truth Plane OpenAPI patch to reference canonical wrapper
- `openapi.truth-plane.patch.yaml` now `$ref`s `./schemas/control-plane/IncidentEvent.json`.

No loss of intent; this removes duplicate authority and keeps both legacy and canonical identities available.
