### PR TITLE
contracts: add shared content/build/release family

### DIFF
--- a/docs/contract-additions/shared-content-build-release-family-v0.md
+++ b/docs/contract-additions/shared-content-build-release-family-v0.md
@@ -1,0 +1,57 @@
+# Shared Content / Build / Release Family v0
+
+This additive contract family introduces shared object shapes that can be reused across:
+
+- SourceOS artifact definitions and release lanes
+- socios build / promotion automation
+- workstation execution evidence
+- office/editor export and publication lanes
+- platform bundle publication
+- catalog and promotion surfaces
+
+## Design intent
+
+The goal is not to force all domains into one execution engine.
+The goal is to let all domains share one object-language for:
+
+- desired content
+- frozen overlays and inputs
+- build requests
+- releases
+- enrollment/consumption profiles
+- evidence bundles
+- catalog entries
+- access profiles
+
+This keeps governance, provenance, and lifecycle semantics aligned even when the
+runtime/build substrate differs.
+
+## Object family
+
+- `ContentSpec`
+- `OverlayBundle`
+- `BuildRequest`
+- `ReleaseManifest`
+- `EnrollmentProfile`
+- `EvidenceBundle`
+- `CatalogEntry`
+- `AccessProfile`
+
+## Boundaries
+
+These schemas are additive. They do **not** replace:
+- `ReleaseReceipt`
+- `RunRecord`
+- `PolicyDecision`
+- `CapabilityToken`
+- existing fog / agent-plane / governance families
+
+Instead, they provide a cross-domain object layer that those families can reference.
+
+## Follow-on
+
+The next tranche after this family lands should add:
+- example payloads
+- fixture validation
+- explicit bindings from runner/evidence/catalog implementations
+- transport-boundary notes for local subprocess IPC vs remote TriTRPC transport

--- a/schemas/AccessProfile.json
+++ b/schemas/AccessProfile.json
@@ -1,0 +1,58 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.srcos.ai/v2/AccessProfile.json",
+  "title": "AccessProfile",
+  "description": "A reusable access and consumption profile describing who may consume or act on governed content in which environments and for which purposes.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["id", "type", "specVersion", "name"],
+  "properties": {
+    "id": {
+      "type": "string",
+      "pattern": "^urn:srcos:access-profile:",
+      "description": "Stable URN identifier. Pattern: urn:srcos:access-profile:<local-id>"
+    },
+    "type": {
+      "const": "AccessProfile",
+      "description": "Discriminator constant — always \"AccessProfile\"."
+    },
+    "specVersion": {
+      "type": "string",
+      "description": "Spec version of this document, e.g. \"2.0.0\"."
+    },
+    "name": {
+      "type": "string",
+      "description": "Human-readable access profile name."
+    },
+    "subjects": {
+      "type": "array",
+      "items": {"type": "string"},
+      "description": "Refs to subject classes, principals, groups, or identities covered by the profile."
+    },
+    "purposes": {
+      "type": "array",
+      "items": {"type": "string"},
+      "description": "Named purposes for which access is allowed."
+    },
+    "allowedContentRefs": {
+      "type": "array",
+      "items": {"type": "string"},
+      "description": "Optional allowlist of content or release refs this profile governs."
+    },
+    "allowedEnvironments": {
+      "type": "array",
+      "items": {"type": "string"},
+      "description": "Named environments or rings in which the profile is valid."
+    },
+    "obligations": {
+      "type": "array",
+      "items": {"type": "string"},
+      "description": "Named obligations or control requirements attached to this profile."
+    },
+    "expiresAt": {
+      "type": ["string", "null"],
+      "format": "date-time",
+      "description": "Optional ISO 8601 expiry for the profile or current issuance."
+    }
+  }
+}

--- a/schemas/BuildRequest.json
+++ b/schemas/BuildRequest.json
@@ -1,0 +1,68 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.srcos.ai/v2/BuildRequest.json",
+  "title": "BuildRequest",
+  "description": "A request to compose a ContentSpec plus zero or more OverlayBundles into one or more output artifacts or bundles.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["id", "type", "specVersion", "contentSpecRef", "outputs", "requestedAt"],
+  "properties": {
+    "id": {
+      "type": "string",
+      "pattern": "^urn:srcos:build-request:",
+      "description": "Stable URN identifier. Pattern: urn:srcos:build-request:<local-id>"
+    },
+    "type": {
+      "const": "BuildRequest",
+      "description": "Discriminator constant — always \"BuildRequest\"."
+    },
+    "specVersion": {
+      "type": "string",
+      "description": "Spec version of this document, e.g. \"2.0.0\"."
+    },
+    "contentSpecRef": {
+      "type": "string",
+      "description": "Reference to the ContentSpec being composed."
+    },
+    "overlayRefs": {
+      "type": "array",
+      "items": {"type": "string"},
+      "description": "Optional overlay bundle refs to apply during composition."
+    },
+    "outputs": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "enum": ["iso", "pxe", "raw", "qcow2", "ami", "bootc", "ostree", "bundle", "docs-export", "other"]
+      },
+      "description": "Requested output artifact surfaces."
+    },
+    "channel": {
+      "type": ["string", "null"],
+      "description": "Optional release channel target such as dev, qa, or prod."
+    },
+    "architecture": {
+      "type": ["string", "null"],
+      "description": "Optional architecture target such as x86_64 or arm64."
+    },
+    "enrollmentProfileRef": {
+      "type": ["string", "null"],
+      "description": "Optional enrollment profile ref for install/runtime consumption."
+    },
+    "parameters": {
+      "type": "object",
+      "additionalProperties": true,
+      "description": "Execution-time parameters that do not change the canonical object family."
+    },
+    "requestedBy": {
+      "type": ["string", "null"],
+      "description": "Optional subject or actor ref that requested the build."
+    },
+    "requestedAt": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO 8601 date-time when the build request was created."
+    }
+  }
+}

--- a/schemas/CatalogEntry.json
+++ b/schemas/CatalogEntry.json
@@ -1,0 +1,59 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.srcos.ai/v2/CatalogEntry.json",
+  "title": "CatalogEntry",
+  "description": "A searchable index record for a governed object, release, or artifact family without redefining the canonical object itself.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["id", "type", "specVersion", "objectRef", "objectType", "status", "updatedAt"],
+  "properties": {
+    "id": {
+      "type": "string",
+      "pattern": "^urn:srcos:catalog-entry:",
+      "description": "Stable URN identifier. Pattern: urn:srcos:catalog-entry:<local-id>"
+    },
+    "type": {
+      "const": "CatalogEntry",
+      "description": "Discriminator constant — always \"CatalogEntry\"."
+    },
+    "specVersion": {
+      "type": "string",
+      "description": "Spec version of this document, e.g. \"2.0.0\"."
+    },
+    "objectRef": {
+      "type": "string",
+      "description": "Reference to the canonical object represented by this catalog entry."
+    },
+    "objectType": {
+      "type": "string",
+      "description": "Type name of the canonical object, such as ReleaseManifest or EvidenceBundle."
+    },
+    "title": {
+      "type": ["string", "null"],
+      "description": "Optional title for indexing and presentation."
+    },
+    "labels": {
+      "type": "object",
+      "additionalProperties": {"type": "string"},
+      "description": "Index labels, tags, or dimensions used for discovery."
+    },
+    "status": {
+      "type": "string",
+      "enum": ["draft", "frozen", "published", "superseded", "restricted", "archived"],
+      "description": "Catalog-visible lifecycle state."
+    },
+    "evidenceBundleRef": {
+      "type": ["string", "null"],
+      "description": "Optional EvidenceBundle ref associated with the indexed object."
+    },
+    "authorityRef": {
+      "type": ["string", "null"],
+      "description": "Optional ref to the authority or namespace governing this entry."
+    },
+    "updatedAt": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO 8601 date-time when this catalog entry was last updated."
+    }
+  }
+}

--- a/schemas/ContentSpec.json
+++ b/schemas/ContentSpec.json
@@ -1,0 +1,57 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.srcos.ai/v2/ContentSpec.json",
+  "title": "ContentSpec",
+  "description": "A canonical desired-content specification that describes a buildable or publishable unit before execution or release.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["id", "type", "specVersion", "name", "kind"],
+  "properties": {
+    "id": {
+      "type": "string",
+      "pattern": "^urn:srcos:content-spec:",
+      "description": "Stable URN identifier. Pattern: urn:srcos:content-spec:<local-id>"
+    },
+    "type": {
+      "const": "ContentSpec",
+      "description": "Discriminator constant — always \"ContentSpec\"."
+    },
+    "specVersion": {
+      "type": "string",
+      "description": "Spec version of this document, e.g. \"2.0.0\"."
+    },
+    "name": {
+      "type": "string",
+      "description": "Human-readable name of the content specification."
+    },
+    "kind": {
+      "type": "string",
+      "enum": ["os-flavor", "overlay-family", "document-export", "automation-bundle", "workspace-pack", "platform-bundle", "model-release", "other"],
+      "description": "Logical content category."
+    },
+    "sourceRefs": {
+      "type": "array",
+      "items": {"type": "string"},
+      "description": "Optional source refs such as git commits, OCI digests, or upstream artifact IDs."
+    },
+    "ownerRef": {
+      "type": ["string", "null"],
+      "description": "Optional owner or authority reference."
+    },
+    "labels": {
+      "type": "object",
+      "additionalProperties": {"type": "string"},
+      "description": "Human or machine labels for indexing and policy."
+    },
+    "policyTags": {
+      "type": "array",
+      "items": {"type": "string"},
+      "description": "Policy and governance tags relevant to this content."
+    },
+    "targetSurfaces": {
+      "type": "array",
+      "items": {"type": "string"},
+      "description": "Named surfaces where this content may be built, installed, published, or consumed."
+    }
+  }
+}

--- a/schemas/EnrollmentProfile.json
+++ b/schemas/EnrollmentProfile.json
@@ -1,0 +1,59 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.srcos.ai/v2/EnrollmentProfile.json",
+  "title": "EnrollmentProfile",
+  "description": "A profile that describes how an installed or activated system should register, enroll, and receive content after boot or first-run.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["id", "type", "specVersion", "name", "registrationMode"],
+  "properties": {
+    "id": {
+      "type": "string",
+      "pattern": "^urn:srcos:enrollment-profile:",
+      "description": "Stable URN identifier. Pattern: urn:srcos:enrollment-profile:<local-id>"
+    },
+    "type": {
+      "const": "EnrollmentProfile",
+      "description": "Discriminator constant — always \"EnrollmentProfile\"."
+    },
+    "specVersion": {
+      "type": "string",
+      "description": "Spec version of this document, e.g. \"2.0.0\"."
+    },
+    "name": {
+      "type": "string",
+      "description": "Human-readable enrollment profile name."
+    },
+    "activationKeyRef": {
+      "type": ["string", "null"],
+      "description": "Optional activation or registration-key reference."
+    },
+    "hostGroupRef": {
+      "type": ["string", "null"],
+      "description": "Optional host-group or grouping reference."
+    },
+    "lifecycleEnvironmentRef": {
+      "type": ["string", "null"],
+      "description": "Optional lifecycle environment ref such as dev, qa, or prod."
+    },
+    "bootstrapUrl": {
+      "type": ["string", "null"],
+      "description": "Optional bootstrap or enrollment URL."
+    },
+    "trustAnchorRefs": {
+      "type": "array",
+      "items": {"type": "string"},
+      "description": "Trust anchors or certificate refs required for enrollment."
+    },
+    "registrationMode": {
+      "type": "string",
+      "enum": ["local_only", "online_registration", "bootstrap_token", "signed_intent"],
+      "description": "How the consumer enrolls or registers after boot/install."
+    },
+    "policyTags": {
+      "type": "array",
+      "items": {"type": "string"},
+      "description": "Governance or operational tags attached to the enrollment profile."
+    }
+  }
+}

--- a/schemas/EvidenceBundle.json
+++ b/schemas/EvidenceBundle.json
@@ -1,0 +1,57 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.srcos.ai/v2/EvidenceBundle.json",
+  "title": "EvidenceBundle",
+  "description": "A bundle of evidence refs, receipts, and logs attached to a subject object such as a release, run, export, or promotion decision.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["id", "type", "specVersion", "subjectRef", "generatedAt"],
+  "properties": {
+    "id": {
+      "type": "string",
+      "pattern": "^urn:srcos:evidence-bundle:",
+      "description": "Stable URN identifier. Pattern: urn:srcos:evidence-bundle:<local-id>"
+    },
+    "type": {
+      "const": "EvidenceBundle",
+      "description": "Discriminator constant — always \"EvidenceBundle\"."
+    },
+    "specVersion": {
+      "type": "string",
+      "description": "Spec version of this document, e.g. \"2.0.0\"."
+    },
+    "subjectRef": {
+      "type": "string",
+      "description": "Ref to the object this evidence bundle supports."
+    },
+    "artifactRefs": {
+      "type": "array",
+      "items": {"type": "string"},
+      "description": "Refs to build outputs, manifests, or related artifacts."
+    },
+    "receiptRefs": {
+      "type": "array",
+      "items": {"type": "string"},
+      "description": "Refs to receipts, attestations, or signature outputs."
+    },
+    "logRefs": {
+      "type": "array",
+      "items": {"type": "string"},
+      "description": "Refs to logs, event streams, or trace bundles."
+    },
+    "decisionRefs": {
+      "type": "array",
+      "items": {"type": "string"},
+      "description": "Refs to policy, promotion, or execution decisions."
+    },
+    "generatedBy": {
+      "type": ["string", "null"],
+      "description": "Optional subject or service that generated the evidence bundle."
+    },
+    "generatedAt": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO 8601 date-time when the evidence bundle was generated."
+    }
+  }
+}

--- a/schemas/OverlayBundle.json
+++ b/schemas/OverlayBundle.json
@@ -1,0 +1,58 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.srcos.ai/v2/OverlayBundle.json",
+  "title": "OverlayBundle",
+  "description": "A frozen additive bundle that can be combined with a ContentSpec during build, install, publish, or runtime activation.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["id", "type", "specVersion", "name", "overlayKind", "embedMode"],
+  "properties": {
+    "id": {
+      "type": "string",
+      "pattern": "^urn:srcos:overlay:",
+      "description": "Stable URN identifier. Pattern: urn:srcos:overlay:<local-id>"
+    },
+    "type": {
+      "const": "OverlayBundle",
+      "description": "Discriminator constant — always \"OverlayBundle\"."
+    },
+    "specVersion": {
+      "type": "string",
+      "description": "Spec version of this document, e.g. \"2.0.0\"."
+    },
+    "name": {
+      "type": "string",
+      "description": "Human-readable overlay bundle name."
+    },
+    "overlayKind": {
+      "type": "string",
+      "enum": ["branding", "ignition", "butane", "network", "certificate", "package", "script", "content", "mixed"],
+      "description": "Primary overlay category."
+    },
+    "sourceRefs": {
+      "type": "array",
+      "items": {"type": "string"},
+      "description": "Frozen refs or digests that define the overlay source."
+    },
+    "checksums": {
+      "type": "array",
+      "items": {"type": "string"},
+      "description": "Checksums or digests associated with the overlay material."
+    },
+    "allowedContentRefs": {
+      "type": "array",
+      "items": {"type": "string"},
+      "description": "Optional allowlist of ContentSpec refs this overlay may be applied to."
+    },
+    "embedMode": {
+      "type": "string",
+      "enum": ["embed", "fetch_at_install", "runtime_only"],
+      "description": "When and how the overlay is introduced."
+    },
+    "policyTags": {
+      "type": "array",
+      "items": {"type": "string"},
+      "description": "Policy and governance tags relevant to this overlay."
+    }
+  }
+}

--- a/schemas/ReleaseManifest.json
+++ b/schemas/ReleaseManifest.json
@@ -1,0 +1,67 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.srcos.ai/v2/ReleaseManifest.json",
+  "title": "ReleaseManifest",
+  "description": "An immutable manifest describing the outputs, digests, labels, and evidence refs for a promoted or publishable release cut.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["id", "type", "specVersion", "createdAt", "status"],
+  "properties": {
+    "id": {
+      "type": "string",
+      "pattern": "^urn:srcos:release:",
+      "description": "Stable URN identifier. Pattern: urn:srcos:release:<local-id>"
+    },
+    "type": {
+      "const": "ReleaseManifest",
+      "description": "Discriminator constant — always \"ReleaseManifest\"."
+    },
+    "specVersion": {
+      "type": "string",
+      "description": "Spec version of this document, e.g. \"2.0.0\"."
+    },
+    "sourceBuildRequestRef": {
+      "type": ["string", "null"],
+      "description": "Optional ref back to the BuildRequest that produced this release."
+    },
+    "artifactRefs": {
+      "type": "array",
+      "items": {"type": "string"},
+      "description": "Refs or URLs for release artifacts or bundle outputs."
+    },
+    "artifactHashes": {
+      "type": "array",
+      "items": {"type": "string"},
+      "description": "Digest values for the artifacts included in this release."
+    },
+    "sbomRefs": {
+      "type": "array",
+      "items": {"type": "string"},
+      "description": "Optional SBOM refs linked to the release outputs."
+    },
+    "evidenceRefs": {
+      "type": "array",
+      "items": {"type": "string"},
+      "description": "Evidence bundles or receipts associated with the release."
+    },
+    "labels": {
+      "type": "object",
+      "additionalProperties": {"type": "string"},
+      "description": "Human or machine labels for channeling, customer rings, or support metadata."
+    },
+    "channel": {
+      "type": ["string", "null"],
+      "description": "Optional release channel such as dev, qa, or prod."
+    },
+    "status": {
+      "type": "string",
+      "enum": ["draft", "published", "superseded", "revoked"],
+      "description": "Lifecycle state of the release manifest."
+    },
+    "createdAt": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO 8601 date-time when the release manifest was created."
+    }
+  }
+}


### PR DESCRIPTION
## Summary

This PR adds the first shared content/build/release object family to `sourceos-spec`.

It is intended as an additive contract layer that can be reused across:
- SourceOS artifact definitions and release lanes
- socios build / promotion automation
- workstation execution and evidence flows
- office/editor export and publication lanes
- platform bundle publication
- catalog and promotion surfaces

## What lands

### Design note
- `docs/contract-additions/shared-content-build-release-family-v0.md`

### New schemas
- `schemas/ContentSpec.json`
- `schemas/OverlayBundle.json`
- `schemas/BuildRequest.json`
- `schemas/ReleaseManifest.json`
- `schemas/EnrollmentProfile.json`
- `schemas/EvidenceBundle.json`
- `schemas/CatalogEntry.json`
- `schemas/AccessProfile.json`

## Why here

`sourceos-spec` already defines itself as the canonical machine-readable contract layer for SourceOS/SociOS, including additive agent-plane and fog-plane families.

That makes it the correct place to introduce a cross-domain object family that can be referenced by:
- substrate/build lanes
- execution planes
- catalog/index surfaces
- publication/export surfaces

## Important boundary notes

This PR does **not** replace existing families such as:
- `ReleaseReceipt`
- `RunRecord`
- `PolicyDecision`
- `CapabilityToken`
- fog-layer contracts
- agent-plane contracts

Instead, it provides a shared object language that those families and downstream repos can reference.

## Follow-on after this

1. add example payloads and fixture validation
2. bind workstation, execution, and catalog surfaces to this family
3. add explicit transport-boundary notes for local subprocess IPC vs remote TriTRPC transport
