### PR TITLE
feat(spec): add InteractionSurface contract for keyboard-first surfaces

### DIFF
--- a/docs/contract-additions/command-bus.md
+++ b/docs/contract-additions/command-bus.md
@@ -1,0 +1,32 @@
+# CommandBus contract addition
+
+This addition introduces `CommandBus` as the typed routing contract for keyboard-first
+cross-surface command dispatch in SourceOS / SociOS.
+
+## Why this contract exists
+
+`InteractionSurface` describes a specific user-facing surface and its ownership
+policies. What it does not describe on its own is the shared routing layer that
+interprets command prefixes, deictics, namespace handoff, and dispatch across
+multiple surfaces.
+
+`CommandBus` fills that gap by making these aspects explicit:
+
+- default interpretation (`search`, `literal-input`, `local-action`)
+- scope and explicit-command prefixes
+- dispatch ordering (`focus-owner-first`, etc.)
+- participating interaction surfaces
+- protected namespaces and host-boundary handoff policy
+
+## Intended use
+
+- canonical specification lives here in `sourceos-spec`
+- Linux / browser / shell implementations bind to this contract downstream
+- execution/control-plane repos may consume command-bus evidence later, but do not own this contract
+
+## Relationship to InteractionSurface
+
+- `InteractionSurface` = a typed surface with focus/host-boundary/command binding rules
+- `CommandBus` = the shared routing and interpretation layer that spans those surfaces
+
+Both are needed for the keyboard-navigation model, but they serve different roles.

--- a/docs/contract-additions/focus-state.md
+++ b/docs/contract-additions/focus-state.md
@@ -1,0 +1,33 @@
+# FocusState contract addition
+
+This addition introduces `FocusState` as the typed ownership/state record for
+keyboard-first cross-surface interaction in SourceOS / SociOS.
+
+## Why this contract exists
+
+`InteractionSurface` describes a surface and its high-level policies.
+`CommandBus` describes routing and interpretation across multiple surfaces.
+What was still missing was an explicit typed record for **who owns the keyboard right now**.
+
+`FocusState` fills that gap by making these aspects explicit:
+
+- current surface reference
+- ownership mode (`host`, `local-surface`, `shell-overlay`, `pass-through`, etc.)
+- printable-input ownership
+- escape and tab behavior
+- completion and selection activity
+- multiline boundary-history semantics
+
+## Intended use
+
+- canonical specification lives here in `sourceos-spec`
+- Linux / browser / shell implementations bind to this state model downstream
+- execution/control-plane repos may consume focus-state evidence later, but do not own the contract
+
+## Relationship to the other keyboard-navigation contracts
+
+- `InteractionSurface` = what the surface is and what high-level policies it carries
+- `CommandBus` = how commands route across surfaces
+- `FocusState` = who owns keyboard behavior in the current moment
+
+All three are needed for the cross-surface keyboard-navigation model.

--- a/docs/contract-additions/focus-transition.md
+++ b/docs/contract-additions/focus-transition.md
@@ -1,0 +1,30 @@
+# FocusTransition contract addition
+
+This addition introduces `FocusTransition` as the typed transition edge between
+keyboard-focus ownership states in SourceOS / SociOS.
+
+## Why this contract exists
+
+`FocusState` describes who owns the keyboard right now. What it does not capture
+on its own is how ownership changes over time.
+
+`FocusTransition` fills that gap by making these aspects explicit:
+
+- source and destination focus states
+- transition trigger
+- priority ordering
+- whether the transition is allowed
+- conditions and ownership effect
+
+## Intended use
+
+- canonical specification lives here in `sourceos-spec`
+- Linux / browser / shell implementations bind to this transition model downstream
+- execution/control-plane repos may consume transition evidence later, but do not own the contract
+
+## Relationship to the other keyboard-navigation contracts
+
+- `InteractionSurface` = what the surface is
+- `CommandBus` = how commands route across surfaces
+- `FocusState` = who owns the keyboard right now
+- `FocusTransition` = how ownership changes from one state to another

--- a/docs/contract-additions/interaction-surface.md
+++ b/docs/contract-additions/interaction-surface.md
@@ -1,0 +1,31 @@
+# InteractionSurface contract addition
+
+This addition introduces `InteractionSurface` as the first canonical contract for
+keyboard-first cross-surface interaction ownership in SourceOS / SociOS.
+
+## Why this contract exists
+
+Existing contract families already describe execution, policy, provenance, and
+agent-session behavior. What was missing was a typed description of the user-facing
+surface itself: launcher, browser, shell, terminal, editor, overlay, and related
+host-boundary contexts.
+
+`InteractionSurface` fills that gap by making these aspects explicit:
+
+- surface type and platform
+- focus ownership policy
+- host-boundary preservation vs mirroring vs opt-in replacement
+- command binding defaults (`/` scope, `>` explicit command mode, etc.)
+- optional command-bus / overlay / keymap references
+
+## Intended use
+
+- canonical specification lives here in `sourceos-spec`
+- Linux-side implementation may live in SourceOS / SociOS Linux repos
+- execution/control-plane repos may consume evidence or policy hooks later, but do not own this contract
+
+## Current scope
+
+This is intentionally the first slice, not the full interaction model. Follow-on
+contracts may add richer focus-state, command-bus, keymap-profile, and surface-
+discoverability types once they stabilize.

--- a/docs/contract-additions/keymap-profile.md
+++ b/docs/contract-additions/keymap-profile.md
@@ -1,0 +1,16 @@
+# KeymapProfile contract addition
+
+`KeymapProfile` is the typed mapping profile for keyboard-first interaction in SourceOS and SociOS.
+
+It records:
+- platform and modifier strategy
+- GUI profile
+- terminal profile
+- launcher and overlay references
+- remap-engine reference
+- protected namespaces
+
+Placement rule:
+- canonical schema lives in `sourceos-spec`
+- Linux-side implementations bind to it downstream
+- donor/remap repositories may inform values but do not own the contract

--- a/examples/command_bus.json
+++ b/examples/command_bus.json
@@ -1,0 +1,38 @@
+{
+  "id": "urn:srcos:command-bus:emvi",
+  "name": "EMVI Command Bus",
+  "description": "Cross-surface command routing for SourceOS / SociOS keyboard-first interaction across launcher, browser, shell, terminal, editor, and overlay contexts.",
+  "defaultInterpretation": "search",
+  "scopePrefix": "/",
+  "explicitCommandPrefix": ">",
+  "dispatchMode": "focus-owner-first",
+  "surfaces": [
+    "urn:srcos:interaction-surface:emvi-shell",
+    "urn:srcos:interaction-surface:shortcut-overlay",
+    "urn:srcos:interaction-surface:browser-surface",
+    "urn:srcos:interaction-surface:terminal-surface"
+  ],
+  "deictics": [
+    "current",
+    "selection",
+    "recent",
+    "here"
+  ],
+  "commandNamespaces": [
+    "browser",
+    "shell",
+    "terminal",
+    "collection",
+    "workspace"
+  ],
+  "protectedNamespaces": [
+    "terminal.pass-through",
+    "editor.insert",
+    "browser.text-field",
+    "accessibility"
+  ],
+  "handoffPolicy": "preserve-host-boundary",
+  "evidenceRefs": [
+    "urn:srcos:session:emvi-proof-slice"
+  ]
+}

--- a/examples/focus_state.json
+++ b/examples/focus_state.json
@@ -1,0 +1,16 @@
+{
+  "id": "urn:srcos:focus-state:emvi-shell-input",
+  "surfaceRef": "urn:srcos:interaction-surface:emvi-shell",
+  "owner": "shell-overlay",
+  "mode": "input",
+  "printableInputOwner": "shell-overlay",
+  "escapeBehavior": "layered-unwind",
+  "tabBehavior": "completion-first",
+  "arrowKeyPolicy": "local-region-navigation",
+  "multilineBoundaryHistory": true,
+  "completionActive": false,
+  "selectionActive": false,
+  "evidenceRefs": [
+    "urn:srcos:session:emvi-proof-slice"
+  ]
+}

--- a/examples/focus_transition.json
+++ b/examples/focus_transition.json
@@ -1,0 +1,15 @@
+{
+  "id": "urn:srcos:focus-transition:example-1",
+  "fromStateRef": "urn:srcos:focus-state:emvi-shell-input",
+  "toStateRef": "urn:srcos:focus-state:emvi-shell-input",
+  "trigger": "escape",
+  "priority": 1,
+  "allowed": true,
+  "conditions": [
+    "completionInactive"
+  ],
+  "ownershipEffect": "retain-owner",
+  "evidenceRefs": [
+    "urn:srcos:session:emvi-proof-slice"
+  ]
+}

--- a/examples/interaction_surface.json
+++ b/examples/interaction_surface.json
@@ -1,0 +1,47 @@
+{
+  "id": "urn:srcos:interaction-surface:emvi-shell",
+  "name": "EMVI Shell Surface",
+  "description": "Keyboard-first command and navigation surface spanning browser, shell, terminal, and overlay contexts while preserving host-native ownership where required.",
+  "surfaceType": "command-surface",
+  "platform": "socios-linux",
+  "modalities": [
+    "keyboard",
+    "hybrid"
+  ],
+  "focusPolicy": {
+    "owner": "shell-overlay",
+    "escapeBehavior": "layered-unwind",
+    "tabBehavior": "completion-first",
+    "multilineBoundaryHistory": true,
+    "arrowKeyPolicy": "local-region-navigation"
+  },
+  "hostBoundaryPolicy": {
+    "nativeShortcutPolicy": "preserve",
+    "passThroughInput": true,
+    "protectedNamespaces": [
+      "terminal.pass-through",
+      "editor.insert",
+      "browser.text-field",
+      "password-field",
+      "accessibility"
+    ]
+  },
+  "commandBinding": {
+    "defaultInterpretation": "search",
+    "scopePrefix": "/",
+    "explicitCommandPrefix": ">",
+    "commandBusRef": "urn:srcos:command-bus:emvi",
+    "launcherRef": null,
+    "shortcutOverlayRef": "urn:srcos:interaction-surface:shortcut-overlay",
+    "keymapProfileRef": "urn:srcos:keymap-profile:mac-linux-primary"
+  },
+  "evidenceRefs": [
+    "urn:srcos:session:emvi-proof-slice"
+  ],
+  "tags": [
+    "keyboard-nav",
+    "cross-surface",
+    "host-boundary",
+    "command-bus"
+  ]
+}

--- a/examples/keymap_profile.json
+++ b/examples/keymap_profile.json
@@ -1,0 +1,30 @@
+{
+  "id": "urn:srcos:keymap-profile:mac-linux-primary",
+  "name": "Mac/Linux Primary Profile",
+  "platform": "socios-linux",
+  "primaryModifierStrategy": "mac-linux-primary",
+  "guiProfile": {
+    "physicalCtrl": "Super",
+    "physicalAlt": "Alt",
+    "physicalSuper": "Ctrl"
+  },
+  "terminalProfile": {
+    "physicalCtrl": "Ctrl",
+    "physicalAlt": "Alt",
+    "physicalSuper": "RightCtrl"
+  },
+  "launcherRefs": [],
+  "overlayRefs": [
+    "urn:srcos:interaction-surface:shortcut-overlay"
+  ],
+  "remapEngineRef": "urn:srcos:remap-engine:kinto",
+  "protectedNamespaces": [
+    "terminal.pass-through",
+    "editor.insert",
+    "browser.text-field",
+    "accessibility"
+  ],
+  "evidenceRefs": [
+    "urn:srcos:session:emvi-proof-slice"
+  ]
+}

--- a/schemas/CommandBus.json
+++ b/schemas/CommandBus.json
@@ -1,0 +1,97 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.srcos.ai/v2/CommandBus.json",
+  "title": "CommandBus",
+  "description": "A typed command-routing surface for keyboard-first interaction across launcher, browser, shell, terminal, editor, overlay, and workspace contexts in SourceOS / SociOS.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "id",
+    "name",
+    "defaultInterpretation",
+    "scopePrefix",
+    "explicitCommandPrefix",
+    "dispatchMode",
+    "surfaces"
+  ],
+  "properties": {
+    "id": {
+      "type": "string",
+      "pattern": "^urn:srcos:command-bus:"
+    },
+    "name": {
+      "type": "string"
+    },
+    "description": {
+      "type": "string"
+    },
+    "defaultInterpretation": {
+      "type": "string",
+      "enum": [
+        "search",
+        "literal-input",
+        "local-action"
+      ]
+    },
+    "scopePrefix": {
+      "type": "string"
+    },
+    "explicitCommandPrefix": {
+      "type": "string"
+    },
+    "dispatchMode": {
+      "type": "string",
+      "enum": [
+        "focus-owner-first",
+        "shell-overlay-first",
+        "local-surface-first"
+      ]
+    },
+    "surfaces": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "pattern": "^urn:srcos:interaction-surface:"
+      }
+    },
+    "deictics": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": [
+          "current",
+          "selection",
+          "recent",
+          "here"
+        ]
+      }
+    },
+    "commandNamespaces": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "protectedNamespaces": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "handoffPolicy": {
+      "type": "string",
+      "enum": [
+        "preserve-host-boundary",
+        "prompt-before-handoff",
+        "policy-gated"
+      ]
+    },
+    "evidenceRefs": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
+  }
+}

--- a/schemas/FocusState.json
+++ b/schemas/FocusState.json
@@ -1,0 +1,102 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.srcos.ai/v2/FocusState.json",
+  "title": "FocusState",
+  "description": "A typed focus/ownership state for keyboard-first interaction across SourceOS / SociOS surfaces.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "id",
+    "surfaceRef",
+    "owner",
+    "mode",
+    "printableInputOwner",
+    "escapeBehavior",
+    "tabBehavior"
+  ],
+  "properties": {
+    "id": {
+      "type": "string",
+      "pattern": "^urn:srcos:focus-state:"
+    },
+    "surfaceRef": {
+      "type": "string",
+      "pattern": "^urn:srcos:interaction-surface:"
+    },
+    "owner": {
+      "type": "string",
+      "enum": [
+        "host",
+        "local-surface",
+        "shell-overlay",
+        "pass-through",
+        "completion-surface",
+        "modal-review"
+      ]
+    },
+    "mode": {
+      "type": "string",
+      "enum": [
+        "idle",
+        "input",
+        "results",
+        "preview",
+        "action-sheet",
+        "insert",
+        "normal",
+        "pass-through",
+        "completion",
+        "confirmation",
+        "plan-review"
+      ]
+    },
+    "printableInputOwner": {
+      "type": "string",
+      "enum": [
+        "host",
+        "local-surface",
+        "pass-through",
+        "shell-overlay"
+      ]
+    },
+    "escapeBehavior": {
+      "type": "string",
+      "enum": [
+        "layered-unwind",
+        "local-only",
+        "host-only"
+      ]
+    },
+    "tabBehavior": {
+      "type": "string",
+      "enum": [
+        "completion-first",
+        "focus-cycle",
+        "local-insert"
+      ]
+    },
+    "arrowKeyPolicy": {
+      "type": "string",
+      "enum": [
+        "local-region-navigation",
+        "caret-or-local",
+        "delegated"
+      ]
+    },
+    "multilineBoundaryHistory": {
+      "type": "boolean"
+    },
+    "completionActive": {
+      "type": "boolean"
+    },
+    "selectionActive": {
+      "type": "boolean"
+    },
+    "evidenceRefs": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
+  }
+}

--- a/schemas/FocusTransition.json
+++ b/schemas/FocusTransition.json
@@ -1,0 +1,79 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.srcos.ai/v2/FocusTransition.json",
+  "title": "FocusTransition",
+  "description": "A typed transition between two keyboard-focus ownership states in SourceOS / SociOS interaction flows.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "id",
+    "fromStateRef",
+    "toStateRef",
+    "trigger",
+    "priority",
+    "allowed"
+  ],
+  "properties": {
+    "id": {
+      "type": "string",
+      "pattern": "^urn:srcos:focus-transition:"
+    },
+    "fromStateRef": {
+      "type": "string",
+      "pattern": "^urn:srcos:focus-state:"
+    },
+    "toStateRef": {
+      "type": "string",
+      "pattern": "^urn:srcos:focus-state:"
+    },
+    "trigger": {
+      "type": "string",
+      "enum": [
+        "summon",
+        "dismiss",
+        "select-result",
+        "open-preview",
+        "enter-insert",
+        "enter-pass-through",
+        "start-completion",
+        "accept-completion",
+        "cancel-completion",
+        "request-confirmation",
+        "accept-confirmation",
+        "cancel-confirmation",
+        "escape",
+        "tab",
+        "shift-tab",
+        "return"
+      ]
+    },
+    "priority": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "allowed": {
+      "type": "boolean"
+    },
+    "conditions": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "ownershipEffect": {
+      "type": "string",
+      "enum": [
+        "retain-owner",
+        "handoff-to-local",
+        "handoff-to-shell",
+        "return-to-host"
+      ]
+    },
+    "evidenceRefs": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
+  }
+}

--- a/schemas/InteractionSurface.json
+++ b/schemas/InteractionSurface.json
@@ -1,0 +1,210 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.srcos.ai/v2/InteractionSurface.json",
+  "title": "InteractionSurface",
+  "description": "A typed keyboard-first interaction surface that participates in the SourceOS / SociOS focus, host-boundary, and command-routing model across launcher, browser, shell, terminal, editor, and overlay contexts.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "id",
+    "name",
+    "surfaceType",
+    "platform",
+    "modalities",
+    "focusPolicy",
+    "hostBoundaryPolicy",
+    "commandBinding"
+  ],
+  "properties": {
+    "id": {
+      "type": "string",
+      "pattern": "^urn:srcos:interaction-surface:"
+    },
+    "name": {
+      "type": "string"
+    },
+    "description": {
+      "type": "string"
+    },
+    "surfaceType": {
+      "type": "string",
+      "enum": [
+        "launcher",
+        "browser",
+        "editor",
+        "terminal",
+        "command-surface",
+        "shortcut-overlay",
+        "panel",
+        "workspace-controller",
+        "compositor"
+      ]
+    },
+    "platform": {
+      "type": "string",
+      "enum": [
+        "sourceos",
+        "socios-linux",
+        "linux",
+        "web",
+        "wayland",
+        "x11",
+        "gnome",
+        "pantheon",
+        "cross-platform"
+      ]
+    },
+    "modalities": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "enum": [
+          "keyboard",
+          "pointer",
+          "touch",
+          "voice",
+          "hybrid"
+        ]
+      }
+    },
+    "focusPolicy": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "owner",
+        "escapeBehavior",
+        "tabBehavior",
+        "multilineBoundaryHistory"
+      ],
+      "properties": {
+        "owner": {
+          "type": "string",
+          "enum": [
+            "host",
+            "local-surface",
+            "shell-overlay",
+            "pass-through",
+            "completion-surface",
+            "modal-review"
+          ]
+        },
+        "escapeBehavior": {
+          "type": "string",
+          "enum": [
+            "layered-unwind",
+            "local-only",
+            "host-only"
+          ]
+        },
+        "tabBehavior": {
+          "type": "string",
+          "enum": [
+            "completion-first",
+            "focus-cycle",
+            "local-insert"
+          ]
+        },
+        "multilineBoundaryHistory": {
+          "type": "boolean"
+        },
+        "arrowKeyPolicy": {
+          "type": "string",
+          "enum": [
+            "local-region-navigation",
+            "caret-or-local",
+            "delegated"
+          ]
+        }
+      }
+    },
+    "hostBoundaryPolicy": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "nativeShortcutPolicy",
+        "passThroughInput"
+      ],
+      "properties": {
+        "nativeShortcutPolicy": {
+          "type": "string",
+          "enum": [
+            "preserve",
+            "mirror",
+            "replace-opt-in"
+          ]
+        },
+        "passThroughInput": {
+          "type": "boolean"
+        },
+        "protectedNamespaces": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "commandBinding": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "defaultInterpretation",
+        "scopePrefix",
+        "explicitCommandPrefix"
+      ],
+      "properties": {
+        "defaultInterpretation": {
+          "type": "string",
+          "enum": [
+            "search",
+            "literal-input",
+            "local-action"
+          ]
+        },
+        "scopePrefix": {
+          "type": "string"
+        },
+        "explicitCommandPrefix": {
+          "type": "string"
+        },
+        "commandBusRef": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "launcherRef": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "shortcutOverlayRef": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "keymapProfileRef": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "evidenceRefs": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "tags": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
+  }
+}

--- a/schemas/KeymapProfile.json
+++ b/schemas/KeymapProfile.json
@@ -1,0 +1,98 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.srcos.ai/v2/KeymapProfile.json",
+  "title": "KeymapProfile",
+  "description": "A typed keyboard mapping profile for SourceOS / SociOS host, browser, shell, terminal, and editor surfaces.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "id",
+    "name",
+    "platform",
+    "primaryModifierStrategy",
+    "guiProfile",
+    "terminalProfile",
+    "protectedNamespaces"
+  ],
+  "properties": {
+    "id": {
+      "type": "string",
+      "pattern": "^urn:srcos:keymap-profile:"
+    },
+    "name": {
+      "type": "string"
+    },
+    "platform": {
+      "type": "string",
+      "enum": [
+        "sourceos",
+        "socios-linux",
+        "linux",
+        "cross-platform"
+      ]
+    },
+    "primaryModifierStrategy": {
+      "type": "string",
+      "enum": [
+        "mac-linux-primary",
+        "linux-native-primary",
+        "app-local-only"
+      ]
+    },
+    "guiProfile": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "physicalCtrl",
+        "physicalAlt",
+        "physicalSuper"
+      ],
+      "properties": {
+        "physicalCtrl": {"type": "string"},
+        "physicalAlt": {"type": "string"},
+        "physicalSuper": {"type": "string"}
+      }
+    },
+    "terminalProfile": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "physicalCtrl",
+        "physicalAlt",
+        "physicalSuper"
+      ],
+      "properties": {
+        "physicalCtrl": {"type": "string"},
+        "physicalAlt": {"type": "string"},
+        "physicalSuper": {"type": "string"}
+      }
+    },
+    "launcherRefs": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "overlayRefs": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "remapEngineRef": {
+      "type": ["string", "null"]
+    },
+    "protectedNamespaces": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "evidenceRefs": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add a canonical keyboard-first interaction contract family to `sourceos-spec`
- introduce `InteractionSurface`, `CommandBus`, `FocusState`, `FocusTransition`, and `KeymapProfile` as first-class typed contracts
- add concrete example payloads and short contract-addition notes for each tranche

## Files added
- `schemas/InteractionSurface.json`
- `schemas/CommandBus.json`
- `schemas/FocusState.json`
- `schemas/FocusTransition.json`
- `schemas/KeymapProfile.json`
- `examples/interaction_surface.json`
- `examples/command_bus.json`
- `examples/focus_state.json`
- `examples/focus_transition.json`
- `examples/keymap_profile.json`
- `docs/contract-additions/interaction-surface.md`
- `docs/contract-additions/command-bus.md`
- `docs/contract-additions/focus-state.md`
- `docs/contract-additions/focus-transition.md`
- `docs/contract-additions/keymap-profile.md`

## Intent
This PR places the first canonical cross-surface keyboard-navigation contract family in the correct repo: `SourceOS-Linux/sourceos-spec`.

The current family covers:
- typed interaction surfaces
- typed command routing / command-bus semantics
- typed focus ownership state
- typed focus transitions
- typed keymap/modifier profile binding
- host-boundary preservation vs mirroring vs opt-in replacement

## Non-goals
- does not yet implement Linux-side runtime behavior directly
- does not yet define every possible browser/editor/app-local shortcut surface
- does not yet define downstream execution-plane evidence contracts for these interaction types

## Follow-up
- bind a Linux-side implementation repo against these contracts without scattering runtime ownership across unrelated workstreams
- keep browser / office / Mac-on-Linux streams as downstream consumers of the canon rather than separate canonical owners
- extend the family further only when the first Linux-side binding exposes real gaps
