### PR TITLE
examples: add shared content/build/release family payloads

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -6,7 +6,7 @@ This directory contains one conforming JSON example payload for each top-level s
 
 ## What the examples show
 
-The examples are designed to tell a coherent end-to-end story: a personal health dataset is catalogued, governed, transformed by an obfuscation workload, and released — all within an agent session. They share cross-reference URNs so you can trace the full lifecycle:
+The examples are designed to tell coherent end-to-end stories. The original example set catalogs, governs, transforms, and releases a personal health dataset within an agent session. Newer SourceOS examples show a SourceOS Workstation artifact flowing from content intent through overlays, build request, release manifest, evidence bundle, catalog entry, and access profile.
 
 ```text
 connector.json       ──► asset.json
@@ -37,6 +37,17 @@ agent_session.json  ──►  execution_decision.json  ──►  session_recei
                                                           │
                                                           ▼
                                                    session_review.json
+
+content_spec.json ──► overlay_bundle.json ──► build_request.json ──► release_manifest.json
+                                                               │               │
+                                                               │               ▼
+                                                       enrollment_profile.json evidence_bundle.json
+                                                                               │
+                                                                               ▼
+                                                                       catalog_entry.json
+                                                                               │
+                                                                               ▼
+                                                                       access_profile.json
 ```
 
 ---
@@ -69,21 +80,44 @@ The fog example set illustrates the new FogVault / FogCompute contract family:
 
 ---
 
+## Recent additions — Shared content / build / release examples
+
+These examples illustrate the shared object family used by SourceOS artifact builds, socios automation, agentplane execution evidence, and catalog surfaces.
+
+| File | Schema type | Description |
+|------|------------|-------------|
+| `content_spec.json` | ContentSpec | SourceOS Workstation content intent / flavor reference |
+| `overlay_bundle.json` | OverlayBundle | Customer branding overlay applied to the workstation flavor |
+| `build_request.json` | BuildRequest | Build request referencing SourceOS content, overlays, enrollment, and agentplane execution refs |
+| `enrollment_profile.json` | EnrollmentProfile | Katello/Foreman enrollment profile for dev workstation installs |
+| `release_manifest.json` | ReleaseManifest | Draft release manifest with Katello artifact refs and agentplane evidence refs |
+| `evidence_bundle.json` | EvidenceBundle | Evidence bundle pointing at agentplane validation/run/replay artifacts |
+| `catalog_entry.json` | CatalogEntry | Searchable catalog entry for the SourceOS Workstation dev release |
+| `access_profile.json` | AccessProfile | Access profile for SourceOS build operators and agentplane executor obligations |
+
+---
+
 ## File index
 
 | File | Schema type | Description |
 |------|------------|-------------|
+| `access_profile.json` | AccessProfile | Access profile for SourceOS build operators and agentplane executor obligations |
 | `agreement.json` | Agreement | Default personal-data agreement |
 | `agent_session.json` | AgentSession | An executor session running the obfuscation workflow |
 | `asset.json` | PhysicalAsset | Lakehouse asset for curated health observations |
+| `build_request.json` | BuildRequest | SourceOS Workstation build request with agentplane and Katello refs |
 | `capability_token.json` | CapabilityToken | Access token scoped to the health dataset export operation |
+| `catalog_entry.json` | CatalogEntry | Catalog entry for the SourceOS Workstation dev release |
 | `comment.json` | Comment | A review note on a field mapping |
 | `community.json` | Community | The data-governance team community |
 | `connector.json` | Connector | A local S3 connector |
 | `content_ref.json` | ContentRef | Content-addressed reference for fog blobs / manifests |
+| `content_spec.json` | ContentSpec | SourceOS Workstation content intent / flavor reference |
 | `dataset.json` | Dataset | Personal health observations dataset |
 | `data_sphere.json` | DataSphere | The personal-curated execution environment |
 | `delta_surface.json` | DeltaSurface | Truth Plane delta surface example |
+| `enrollment_profile.json` | EnrollmentProfile | Katello/Foreman enrollment profile for dev workstation installs |
+| `evidence_bundle.json` | EvidenceBundle | Evidence bundle pointing at agentplane validation/run/replay artifacts |
 | `execution_decision.json` | ExecutionDecision | Agent allow-decision for a tool invocation |
 | `event_envelope.json` | EventEnvelope | Event published when the run completes |
 | `experiment_flag.json` | ExperimentFlag | A feature flag for the new obfuscation algorithm |
@@ -93,10 +127,12 @@ The fog example set illustrates the new FogVault / FogCompute contract family:
 | `mapping.json` | MappingSpec | A field mapping between two dataset fields |
 | `memory_entry.json` | MemoryEntry | A learned memory entry from an agent session |
 | `offer.json` | Offer | FogCompute provider offer |
+| `overlay_bundle.json` | OverlayBundle | Customer branding overlay applied to the workstation flavor |
 | `policy.json` | Policy | Health export must be obfuscated |
 | `policy_decision.json` | PolicyDecision | An `export` permit decision with an obfuscation obligation |
 | `provenance.json` | ProvenanceRecord | Provenance record for the obfuscation run |
 | `rating.json` | Rating | A 5-star rating on the health observations dataset |
+| `release_manifest.json` | ReleaseManifest | Draft release manifest with Katello artifact refs and agentplane evidence refs |
 | `release_receipt.json` | ReleaseReceipt | Release receipt for spec version 2.0.0 |
 | `replication_policy.json` | ReplicationPolicy | Fog topic replication/retention policy example |
 | `rollout_policy.json` | RolloutPolicy | Rollout rules for the obfuscation experiment flag |

--- a/examples/access_profile.json
+++ b/examples/access_profile.json
@@ -1,0 +1,29 @@
+{
+  "id": "urn:srcos:access-profile:sourceos-workstation-dev-builders",
+  "type": "AccessProfile",
+  "specVersion": "2.0.0",
+  "name": "SourceOS workstation dev builders",
+  "subjects": [
+    "urn:srcos:community:sourceos-build-operators",
+    "agentplane://executor/sourceos-builder"
+  ],
+  "purposes": [
+    "build",
+    "publish",
+    "smoke-test"
+  ],
+  "allowedContentRefs": [
+    "urn:srcos:content-spec:sourceos-workstation",
+    "urn:srcos:release:sourceos-workstation-dev-0001"
+  ],
+  "allowedEnvironments": [
+    "dev"
+  ],
+  "obligations": [
+    "emit:ValidationArtifact",
+    "emit:RunArtifact",
+    "emit:ReplayArtifact",
+    "emit:EvidenceBundle"
+  ],
+  "expiresAt": null
+}

--- a/examples/build_request.json
+++ b/examples/build_request.json
@@ -1,0 +1,25 @@
+{
+  "id": "urn:srcos:build-request:sourceos-workstation-dev-0001",
+  "type": "BuildRequest",
+  "specVersion": "2.0.0",
+  "contentSpecRef": "urn:srcos:content-spec:sourceos-workstation",
+  "overlayRefs": [
+    "urn:srcos:overlay:customer-branding-acme"
+  ],
+  "outputs": [
+    "iso",
+    "pxe"
+  ],
+  "channel": "dev",
+  "architecture": "x86_64",
+  "enrollmentProfileRef": "urn:srcos:enrollment-profile:default-workstation",
+  "parameters": {
+    "agentplaneBundleRef": "github://SocioProphet/agentplane/examples/sourceos/sourceos-build-release-bindings.example.json@main",
+    "localExecutionProtocolRef": "urn:srcos:contract:workstation-contracts:m2-ipc:v1.0",
+    "remoteExecutionProtocolRef": "urn:srcos:protocol:tritrpc:v1",
+    "katelloProduct": "SourceOS Files",
+    "katelloRepository": "sourceos-live-iso"
+  },
+  "requestedBy": "urn:srcos:party:sourceos-build-operator",
+  "requestedAt": "2026-04-24T00:00:00Z"
+}

--- a/examples/catalog_entry.json
+++ b/examples/catalog_entry.json
@@ -1,0 +1,19 @@
+{
+  "id": "urn:srcos:catalog-entry:sourceos-workstation-dev-0001",
+  "type": "CatalogEntry",
+  "specVersion": "2.0.0",
+  "objectRef": "urn:srcos:release:sourceos-workstation-dev-0001",
+  "objectType": "ReleaseManifest",
+  "title": "SourceOS Workstation dev live installer release 0001",
+  "labels": {
+    "flavor": "sourceos-workstation",
+    "channel": "dev",
+    "surface": "live-usb",
+    "executionPlane": "agentplane",
+    "contentPlane": "katello"
+  },
+  "status": "draft",
+  "evidenceBundleRef": "urn:srcos:evidence-bundle:sourceos-workstation-dev-0001",
+  "authorityRef": "github://SociOS-Linux/SourceOS/manifests/release-manifest.example.json@main",
+  "updatedAt": "2026-04-24T00:20:00Z"
+}

--- a/examples/content_spec.json
+++ b/examples/content_spec.json
@@ -1,0 +1,26 @@
+{
+  "id": "urn:srcos:content-spec:sourceos-workstation",
+  "type": "ContentSpec",
+  "specVersion": "2.0.0",
+  "name": "SourceOS Workstation",
+  "kind": "os-flavor",
+  "sourceRefs": [
+    "github://SociOS-Linux/SourceOS/flavors/sourceos-workstation.example.yaml@main"
+  ],
+  "ownerRef": "urn:srcos:party:sourceos-linux",
+  "labels": {
+    "family": "workstation",
+    "substrate": "fcos",
+    "releaseLane": "dev"
+  },
+  "policyTags": [
+    "sourceos.substrate",
+    "fcos.thin-personalization",
+    "agentplane.execution-boundary"
+  ],
+  "targetSurfaces": [
+    "sourceos-live-usb",
+    "sourceos-pxe",
+    "agentplane-bundle"
+  ]
+}

--- a/examples/enrollment_profile.json
+++ b/examples/enrollment_profile.json
@@ -1,0 +1,19 @@
+{
+  "id": "urn:srcos:enrollment-profile:default-workstation",
+  "type": "EnrollmentProfile",
+  "specVersion": "2.0.0",
+  "name": "Default SourceOS Workstation enrollment",
+  "activationKeyRef": "katello://SourceOS/activation-keys/sourceos-workstation-dev",
+  "hostGroupRef": "foreman://SourceOS/host-groups/sourceos-workstation",
+  "lifecycleEnvironmentRef": "katello://SourceOS/lifecycle/dev",
+  "bootstrapUrl": "https://enroll.sourceos.local/register",
+  "trustAnchorRefs": [
+    "urn:srcos:content-ref:sourceos-ca"
+  ],
+  "registrationMode": "bootstrap_token",
+  "policyTags": [
+    "sourceos.enrollment",
+    "katello.activation-key",
+    "short-lived-bootstrap"
+  ]
+}

--- a/examples/evidence_bundle.json
+++ b/examples/evidence_bundle.json
@@ -1,0 +1,23 @@
+{
+  "id": "urn:srcos:evidence-bundle:sourceos-workstation-dev-0001",
+  "type": "EvidenceBundle",
+  "specVersion": "2.0.0",
+  "subjectRef": "urn:srcos:release:sourceos-workstation-dev-0001",
+  "artifactRefs": [
+    "katello://SourceOS/SourceOS%20Files/sourceos-live-iso/sourceos-workstation-dev-0001.iso"
+  ],
+  "receiptRefs": [
+    "agentplane://validation-artifact/sourceos-workstation-dev-0001",
+    "agentplane://run-artifact/sourceos-workstation-dev-0001",
+    "agentplane://replay-artifact/sourceos-workstation-dev-0001"
+  ],
+  "logRefs": [
+    "agentplane://logs/sourceos-workstation-dev-0001/stdout",
+    "agentplane://logs/sourceos-workstation-dev-0001/stderr"
+  ],
+  "decisionRefs": [
+    "urn:srcos:decision:sourceos-workstation-dev-0001-policy-allow"
+  ],
+  "generatedBy": "agentplane://bundle/sourceos-workstation-dev-0001",
+  "generatedAt": "2026-04-24T00:15:00Z"
+}

--- a/examples/overlay_bundle.json
+++ b/examples/overlay_bundle.json
@@ -1,0 +1,22 @@
+{
+  "id": "urn:srcos:overlay:customer-branding-acme",
+  "type": "OverlayBundle",
+  "specVersion": "2.0.0",
+  "name": "ACME workstation branding overlay",
+  "overlayKind": "branding",
+  "sourceRefs": [
+    "github://SociOS-Linux/SourceOS/overlays/acme-branding@main"
+  ],
+  "checksums": [
+    "sha256:1111111111111111111111111111111111111111111111111111111111111111"
+  ],
+  "allowedContentRefs": [
+    "urn:srcos:content-spec:sourceos-workstation"
+  ],
+  "embedMode": "embed",
+  "policyTags": [
+    "overlay.branding",
+    "customer.acme",
+    "sourceos.install-media"
+  ]
+}

--- a/examples/release_manifest.json
+++ b/examples/release_manifest.json
@@ -1,0 +1,31 @@
+{
+  "id": "urn:srcos:release:sourceos-workstation-dev-0001",
+  "type": "ReleaseManifest",
+  "specVersion": "2.0.0",
+  "sourceBuildRequestRef": "urn:srcos:build-request:sourceos-workstation-dev-0001",
+  "artifactRefs": [
+    "katello://SourceOS/SourceOS%20Files/sourceos-live-iso/sourceos-workstation-dev-0001.iso",
+    "katello://SourceOS/SourceOS%20Files/sourceos-config-bundles/sourceos-workstation-dev-0001.tar.zst"
+  ],
+  "artifactHashes": [
+    "sha256:2222222222222222222222222222222222222222222222222222222222222222",
+    "sha256:3333333333333333333333333333333333333333333333333333333333333333"
+  ],
+  "sbomRefs": [
+    "urn:srcos:content-ref:sourceos-workstation-dev-0001-sbom"
+  ],
+  "evidenceRefs": [
+    "urn:srcos:evidence-bundle:sourceos-workstation-dev-0001",
+    "agentplane://run-artifact/sourceos-workstation-dev-0001",
+    "agentplane://replay-artifact/sourceos-workstation-dev-0001"
+  ],
+  "labels": {
+    "flavor": "sourceos-workstation",
+    "channel": "dev",
+    "surface": "live-usb",
+    "agentplaneBundle": "sourceos-workstation-dev-0001"
+  },
+  "channel": "dev",
+  "status": "draft",
+  "createdAt": "2026-04-24T00:10:00Z"
+}


### PR DESCRIPTION
## Summary

Adds conforming example payloads for the shared content/build/release object family that landed in PR #45.

The examples tell a coherent SourceOS Workstation build/release story and intentionally integrate with `agentplane` where execution evidence belongs.

## What lands

### New examples
- `examples/content_spec.json`
- `examples/overlay_bundle.json`
- `examples/build_request.json`
- `examples/enrollment_profile.json`
- `examples/release_manifest.json`
- `examples/evidence_bundle.json`
- `examples/catalog_entry.json`
- `examples/access_profile.json`

### Documentation
- updates `examples/README.md` with a new shared content/build/release section and file-index entries

## Agentplane integration

The examples do not duplicate execution truth. They reference `agentplane` where appropriate:
- `build_request.json` includes `agentplaneBundleRef`, local M2 IPC protocol ref, and remote TriTRPC protocol ref
- `release_manifest.json` references agentplane run/replay artifacts in `evidenceRefs`
- `evidence_bundle.json` references agentplane validation/run/replay artifacts as receipts
- `catalog_entry.json` labels the execution plane as `agentplane`
- `access_profile.json` includes the agentplane executor as an allowed subject and evidence-emission obligations

## Why

The shared object family is now merged, but downstream implementation needs canonical payload examples to align SourceOS artifact truth, socios automation, agentplane execution evidence, and catalog semantics.

## Non-goals

This PR does not add validators or schema changes. It is examples-only plus README indexing.
