### PR TITLE
feat(spec): add initial CompressionEvaluation contract

### DIFF
--- a/examples/compressionevaluation.json
+++ b/examples/compressionevaluation.json
@@ -1,0 +1,53 @@
+{
+  "id": "urn:srcos:compression-eval:ce_0001",
+  "type": "CompressionEvaluation",
+  "specVersion": "2.0.0",
+  "artifact": {
+    "contentRef": {
+      "digest": "sha256:artifact_example_digest",
+      "sizeBytes": 2048,
+      "mediaType": "application/json",
+      "uris": ["file:///var/lib/srcos/artifacts/ce_0001.json"]
+    }
+  },
+  "baseline": {
+    "dataRef": {
+      "refType": "dataset",
+      "id": "urn:srcos:dataset:health_obs"
+    }
+  },
+  "purpose": "promotion-review",
+  "estimatorSet": {
+    "name": "compression-commons-basic",
+    "version": "0.1.0",
+    "family": "compression",
+    "params": {
+      "window": 4096,
+      "normalization": "token"
+    }
+  },
+  "metrics": {
+    "novelty": 0.82,
+    "redundancy": 0.14,
+    "supportingMetrics": {
+      "support": 0.73,
+      "stability": 0.91
+    },
+    "confidence": 0.88,
+    "warnings": [],
+    "normalizationVersion": "0.1.0"
+  },
+  "policyDecisionRef": "urn:srcos:decision:aa11bb22",
+  "runRecordRef": "urn:srcos:run:77cc88dd",
+  "provenanceRef": "urn:srcos:prov:001",
+  "truthSurfaceRef": "urn:srcos:truth-surface:ts_0001",
+  "deltaSurfaceRef": "urn:srcos:delta-surface:ds_0001",
+  "integrity": {
+    "evaluationHash": "sha256:evaluation_example_digest",
+    "signer": "sourceos-compression-evaluator",
+    "signature": "sig:example_signature",
+    "signedAt": "2026-04-25T16:00:00Z"
+  },
+  "notes": "Example CompressionEvaluation composed from existing governance, execution, provenance, and reference objects.",
+  "createdAt": "2026-04-25T16:00:00Z"
+}

--- a/schemas/CompressionEvaluation.json
+++ b/schemas/CompressionEvaluation.json
@@ -1,0 +1,107 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.srcos.ai/v2/CompressionEvaluation.json",
+  "title": "CompressionEvaluation",
+  "description": "Immutable artifact-versus-baseline evaluation record.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "id",
+    "type",
+    "specVersion",
+    "artifact",
+    "baseline",
+    "estimatorSet",
+    "metrics",
+    "createdAt"
+  ],
+  "properties": {
+    "id": {
+      "type": "string",
+      "pattern": "^urn:srcos:compression-eval:",
+      "description": "Stable URN identifier."
+    },
+    "type": {
+      "const": "CompressionEvaluation",
+      "description": "Discriminator constant."
+    },
+    "specVersion": {
+      "type": "string",
+      "description": "Spec version string."
+    },
+    "artifact": {
+      "type": "object",
+      "description": "Artifact under evaluation.",
+      "additionalProperties": false,
+      "properties": {
+        "contentRef": { "$ref": "ContentRef.json" },
+        "dataRef": { "$ref": "DataRef.json" }
+      },
+      "anyOf": [
+        { "required": ["contentRef"] },
+        { "required": ["dataRef"] }
+      ]
+    },
+    "baseline": {
+      "type": "object",
+      "description": "Baseline used for comparison.",
+      "additionalProperties": false,
+      "properties": {
+        "contentRef": { "$ref": "ContentRef.json" },
+        "dataRef": { "$ref": "DataRef.json" }
+      },
+      "anyOf": [
+        { "required": ["contentRef"] },
+        { "required": ["dataRef"] }
+      ]
+    },
+    "purpose": {
+      "type": ["string", "null"],
+      "description": "Optional declared evaluation purpose."
+    },
+    "estimatorSet": {
+      "type": "object",
+      "description": "Versioned estimator configuration.",
+      "additionalProperties": false,
+      "required": ["name", "version"],
+      "properties": {
+        "name": { "type": "string", "description": "Estimator name." },
+        "version": { "type": "string", "description": "Estimator version." },
+        "family": { "type": ["string", "null"], "description": "Optional family label." },
+        "params": { "type": "object", "additionalProperties": true, "description": "Replayable estimator parameters." }
+      }
+    },
+    "metrics": {
+      "type": "object",
+      "description": "Evaluation outputs.",
+      "additionalProperties": false,
+      "required": ["novelty", "redundancy"],
+      "properties": {
+        "novelty": { "type": "number", "description": "Primary novelty signal." },
+        "redundancy": { "type": "number", "description": "Primary redundancy signal." },
+        "confidence": { "type": ["number", "null"], "description": "Optional confidence score." },
+        "warnings": { "type": "array", "items": { "type": "string" }, "description": "Optional warnings." }
+      }
+    },
+    "policyDecisionRef": {
+      "type": ["string", "null"],
+      "pattern": "^urn:srcos:decision:",
+      "description": "Optional policy decision reference."
+    },
+    "runRecordRef": {
+      "type": ["string", "null"],
+      "pattern": "^urn:srcos:run:",
+      "description": "Optional evaluator run reference."
+    },
+    "provenanceRef": {
+      "type": ["string", "null"],
+      "pattern": "^urn:srcos:prov:",
+      "description": "Optional provenance reference."
+    },
+    "createdAt": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Creation timestamp."
+    }
+  }
+}


### PR DESCRIPTION
## Summary
Adds the first actual Compression Commons contract slice to `sourceos-spec` after the placement decision in #58.

## Added
- `schemas/CompressionEvaluation.json`
- `examples/compressionevaluation.json`

## Intent
`CompressionEvaluation` is the canonical metadata-plane record for one artifact-versus-baseline evaluation. It composes existing typed contracts rather than duplicating them:
- `ContentRef` / `DataRef` for artifact and baseline references
- `PolicyDecision` by reference for adjudication
- `RunRecord` by reference for evaluator execution
- `ProvenanceRecord` by reference for lineage

## Scope
This first slice deliberately stays narrow:
- no `ArtifactRef` top-level schema
- no `CorpusSnapshotRef` top-level schema
- no `MetricVector` top-level schema
- no AsyncAPI channel in v0
- no agent-plane patch in v0

## Upstream handling
I checked upstream before opening this PR. PRs #59 and #60 had moved `main`, and #58 was then merged cleanly. This branch was recreated from the merged `main` (`ed1b465...`) and is now cleanly ahead by only these two files.

## Follow-up
A second contract-hygiene PR should wire this into:
- `schemas/README.md`
- `ARCHITECTURE.md`
- `openapi.yaml`
- `semantic/context.jsonld`
- `semantic/hydra.jsonld`
- `CHANGELOG.md`
