### PR TITLE
docs(spec): record CompressionEvaluation in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). Thi
 ## [Unreleased]
 
 ### Added
+- Compression Commons: `CompressionEvaluation` schema and canonical example (`examples/compressionevaluation.json`)
 - Truth Plane: `TruthSurface` and `DeltaSurface` schemas + canonical examples (`examples/truth_surface.json`, `examples/delta_surface.json`)
 - Control-plane: `IncidentEvent` schema for incident lifecycle events
 - Control-plane: canonical wrapper `$id` model for legacy schemas (`schemas/control-plane/*.json` wrappers)


### PR DESCRIPTION
## Summary
Adds the missing `CHANGELOG.md` entry for the merged CompressionEvaluation schema/example work from #61.

## Why
PR #61 intentionally landed a narrow contract slice. This follow-up keeps the public change log aligned without mixing in the larger catalog/OpenAPI/semantic edits.

## Added
- Unreleased changelog bullet for `CompressionEvaluation` schema and canonical example.

## Scope
- changelog only
- no schema changes
- no OpenAPI changes
- no semantic overlay changes

## Follow-up
The next hygiene tranche should wire `CompressionEvaluation` into `schemas/README.md`, `ARCHITECTURE.md`, `openapi.yaml`, and semantic overlay files.
