### PR TITLE
Harden BootReleaseSet control-plane contract

### DIFF
--- a/examples/boot_release_set.json
+++ b/examples/boot_release_set.json
@@ -2,12 +2,73 @@
   "boot_release_set_id": "urn:srcos:boot-release-set:m2-demo-recovery-2026-04-26",
   "base_release_set_ref": "urn:srcos:release-set:m2-demo-2026-04-26",
   "boot_mode": "recovery",
+  "boot_channel": "rescue",
   "status": "ready",
+  "platform_entrypoints": [
+    {
+      "platform": "apple-silicon",
+      "entrypoint_kind": "asahi-installer-entry",
+      "entrypoint_ref": "urn:srcos:boot-entry:m2-demo-sourceos-recovery-asahi-installer",
+      "requires_network": true,
+      "notes": "Models the SourceOS Recovery Environment as an Apple Silicon boot-picker compatible installer/recovery entry using Asahi-style installer metadata hosting."
+    },
+    {
+      "platform": "uefi-ipxe",
+      "entrypoint_kind": "ipxe-menu-entry",
+      "entrypoint_ref": "urn:srcos:boot-entry:generic-ipxe-sourceos-recovery",
+      "requires_network": true,
+      "notes": "Portable PXE-like entrypoint for later PC/Purism/generic UEFI targets."
+    }
+  ],
   "artifacts": {
+    "manifest_ref": "urn:srcos:artifact:m2-demo-recovery-manifest-sha256-6e6f74626f6f74",
     "kernel_ref": "urn:srcos:artifact:m2-demo-recovery-kernel-sha256-0f3b6d7f",
     "initrd_ref": "urn:srcos:artifact:m2-demo-recovery-initrd-sha256-08f4c82e",
-    "rootfs_ref": "urn:srcos:artifact:m2-demo-recovery-rootfs-sha256-5f4dcc3b"
+    "rootfs_ref": "urn:srcos:artifact:m2-demo-recovery-rootfs-sha256-5f4dcc3b",
+    "bootloader_ref": "urn:srcos:artifact:m2-demo-m1n1-uboot-chain-sha256-7a38f2d1",
+    "installer_metadata_ref": "urn:srcos:artifact:m2-demo-asahi-installer-data-sha256-3f9c1f44"
+  },
+  "policy_ref": "urn:srcos:policy:boot-recovery-m2-demo-v1",
+  "signing": {
+    "signature_ref": "urn:srcos:signature:m2-demo-recovery-manifest-rsa-pss-sha256",
+    "signer_ref": "urn:srcos:key:sourceos-release-root",
+    "signature_algorithm": "rsa-pss-sha256",
+    "manifest_digest": {
+      "algorithm": "sha256",
+      "value": "sha256:6e6f74626f6f742d6d322d7265636f766572792d64656d6f"
+    }
+  },
+  "boot_capabilities": {
+    "disk_write": "recovery-scoped",
+    "network_required": true,
+    "kexec_allowed": false,
+    "recovery_actions": [
+      "fetch-release-set",
+      "rollback-system",
+      "repair-user-plane",
+      "repair-agent-plane",
+      "rotate-keys",
+      "report-proof"
+    ]
+  },
+  "proof_reporting": {
+    "required": true,
+    "reports": [
+      "device-claim",
+      "environment-fingerprint",
+      "manifest-digest",
+      "artifact-hash-manifest",
+      "policy-decision",
+      "rollback-result"
+    ],
+    "endpoint_ref": "urn:srcos:endpoint:control-plane-boot-proof-report"
+  },
+  "offline_fallback": {
+    "enabled": true,
+    "strategy": "last-known-good-signed-boot-release-set",
+    "requires_signature_verification": true,
+    "allows_unsigned_artifacts": false
   },
   "created_at": "2026-04-26T14:30:00Z",
-  "notes": "SourceOS Recovery Environment for the M2 local-first demo. This models the nlboot-evolved recovery path: minimal boot artifacts, signed content-addressed refs, and linkage back to the assigned ReleaseSet."
+  "notes": "SourceOS Recovery Environment for the M2 local-first demo. This models the nlboot-evolved recovery path: minimal boot artifacts, signed content-addressed refs, policy-scoped recovery actions, proof reporting, Apple Silicon boot-picker integration, portable UEFI/iPXE semantics, and linkage back to the assigned ReleaseSet."
 }

--- a/schemas/control-plane/boot-release-set.schema.json
+++ b/schemas/control-plane/boot-release-set.schema.json
@@ -2,15 +2,22 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://socioprophet.org/schemas/control-plane/boot-release-set.schema.json",
   "title": "BootReleaseSet",
-  "description": "Boot/install or recovery artifacts associated with a local-first release assignment.",
+  "description": "Boot, install, live, or recovery artifact set associated with a local-first release assignment. A BootReleaseSet extends a ReleaseSet with signed boot artifacts, platform entrypoints, policy linkage, proof reporting, and offline fallback semantics.",
   "type": "object",
   "additionalProperties": false,
   "required": [
     "boot_release_set_id",
     "base_release_set_ref",
     "boot_mode",
+    "boot_channel",
     "status",
+    "platform_entrypoints",
     "artifacts",
+    "policy_ref",
+    "signing",
+    "boot_capabilities",
+    "proof_reporting",
+    "offline_fallback",
     "created_at"
   ],
   "properties": {
@@ -20,18 +27,120 @@
       "type": "string",
       "enum": ["installer", "recovery", "ephemeral", "bootstrap"]
     },
+    "boot_channel": {
+      "type": "string",
+      "enum": ["live", "installer", "rescue", "rollback", "bootstrap"]
+    },
     "status": {
       "type": "string",
       "enum": ["draft", "ready", "retired"]
     },
+    "platform_entrypoints": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["platform", "entrypoint_kind", "entrypoint_ref"],
+        "properties": {
+          "platform": {
+            "type": "string",
+            "enum": ["apple-silicon", "uefi-ipxe", "uefi-httpboot", "generic-linux", "unknown"]
+          },
+          "entrypoint_kind": {
+            "type": "string",
+            "enum": ["asahi-installer-entry", "apple-boot-picker-entry", "ipxe-menu-entry", "uefi-httpboot-entry", "local-bootstrap-media", "manual"]
+          },
+          "entrypoint_ref": { "type": "string", "minLength": 1 },
+          "requires_network": { "type": ["boolean", "null"] },
+          "notes": { "type": ["string", "null"] }
+        }
+      }
+    },
     "artifacts": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["kernel_ref", "initrd_ref", "rootfs_ref"],
+      "required": ["manifest_ref", "kernel_ref", "initrd_ref", "rootfs_ref"],
       "properties": {
+        "manifest_ref": { "type": "string", "minLength": 1 },
         "kernel_ref": { "type": "string", "minLength": 1 },
         "initrd_ref": { "type": "string", "minLength": 1 },
-        "rootfs_ref": { "type": "string", "minLength": 1 }
+        "rootfs_ref": { "type": "string", "minLength": 1 },
+        "bootloader_ref": { "type": ["string", "null"] },
+        "installer_metadata_ref": { "type": ["string", "null"] }
+      }
+    },
+    "policy_ref": { "type": "string", "minLength": 1 },
+    "signing": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["signature_ref", "signer_ref", "signature_algorithm", "manifest_digest"],
+      "properties": {
+        "signature_ref": { "type": "string", "minLength": 1 },
+        "signer_ref": { "type": "string", "minLength": 1 },
+        "signature_algorithm": {
+          "type": "string",
+          "enum": ["rsa-pss-sha256", "ed25519", "ecdsa-p256-sha256"]
+        },
+        "manifest_digest": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["algorithm", "value"],
+          "properties": {
+            "algorithm": { "type": "string", "enum": ["sha256", "sha384", "sha512"] },
+            "value": { "type": "string", "minLength": 1 }
+          }
+        }
+      }
+    },
+    "boot_capabilities": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["disk_write", "network_required", "kexec_allowed", "recovery_actions"],
+      "properties": {
+        "disk_write": {
+          "type": "string",
+          "enum": ["denied", "installer-scoped", "recovery-scoped"]
+        },
+        "network_required": { "type": "boolean" },
+        "kexec_allowed": { "type": "boolean" },
+        "recovery_actions": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": ["fetch-release-set", "install", "rollback-system", "repair-user-plane", "repair-agent-plane", "rotate-keys", "report-proof"]
+          }
+        }
+      }
+    },
+    "proof_reporting": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["required", "reports"],
+      "properties": {
+        "required": { "type": "boolean" },
+        "reports": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": ["device-claim", "environment-fingerprint", "manifest-digest", "artifact-hash-manifest", "policy-decision", "rollback-result", "install-result"]
+          }
+        },
+        "endpoint_ref": { "type": ["string", "null"] }
+      }
+    },
+    "offline_fallback": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["enabled", "strategy", "requires_signature_verification", "allows_unsigned_artifacts"],
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "strategy": {
+          "type": "string",
+          "enum": ["none", "last-known-good-boot-release-set", "last-known-good-signed-boot-release-set"]
+        },
+        "requires_signature_verification": { "type": "boolean" },
+        "allows_unsigned_artifacts": { "type": "boolean" }
       }
     },
     "created_at": { "type": "string", "format": "date-time" },


### PR DESCRIPTION
## Summary

Hardens the control-plane `BootReleaseSet` contract so it can act as the SourceOS bootable ReleaseSet object for live, installer, rescue, rollback, and bootstrap lanes.

## Scope

- Adds `boot_channel` to distinguish live/install/rescue/rollback/bootstrap semantics.
- Adds platform entrypoints for Apple Silicon and portable UEFI/iPXE-style targets.
- Adds signed manifest semantics with signer, signature algorithm, and manifest digest.
- Adds policy linkage via `policy_ref`.
- Adds explicit boot capabilities for disk write posture, network requirement, kexec posture, and recovery actions.
- Adds proof reporting requirements.
- Adds signed offline fallback posture.
- Updates the M2 demo `boot_release_set.json` example to prove the operational shape.

## Non-goals

- Does not implement boot execution.
- Does not add host-mutating behavior.
- Does not claim production installer readiness.
- Does not change unrelated schema families.

## Validation

Expected:

```bash
make validate
```

This is the contract required before `SourceOS-Linux/sourceos-boot` implements the live/recovery/proof path.