### PR TITLE
Add Network Door, Mesh Door, BYOM, and native assistant contracts

### DIFF
--- a/docs/contract-additions/README.md
+++ b/docs/contract-additions/README.md
@@ -5,6 +5,7 @@ This directory contains discoverability notes for additive SourceOS/SociOS contr
 | Addition | Purpose | Key schemas |
 |---|---|---|
 | [Agent Machine Local Data Plane and TopoLVM Mount Contracts](agent-machine-local-data-plane.md) | Defines safe local workspace mounts for Agent Machine and maps the same logical contract to TopoLVM-backed node-local persistent volumes in cluster mode. | `AgentMachineLocalDataPlane`, `AgentMachineMountPolicy`, `TopoLVMPlacementProfile` |
+| [Network, Mesh, BYOM, and Native Assistant Door Contracts](network-assistant-model-doors.md) | Defines enterprise/user network profiles, firewall bindings, service-mesh bindings, BYOM model endpoints, and native assistant bridges such as Apple App Intents/Siri/Shortcuts-style integrations. | `NetworkAccessProfile`, `FirewallBindingProfile`, `MeshBindingProfile`, `ExternalModelProviderProfile`, `NativeAssistantBridgeProfile` |
 
 ## Rules for additions
 

--- a/docs/contract-additions/network-assistant-model-doors.md
+++ b/docs/contract-additions/network-assistant-model-doors.md
@@ -1,0 +1,110 @@
+# Network, Mesh, BYOM, and Native Assistant Door contracts
+
+This contract addition defines the SourceOS boundary for enterprise networking, user firewalls, service mesh integrations, bring-your-own-model endpoints, and native assistant bridges such as Apple App Intents/Siri/Shortcuts.
+
+## Why this exists
+
+Enterprise customers need SourceOS Agent Machine, Office Plane, Local Model Door, and external model routing to respect corporate firewall and service-mesh policy. Individual users also need their own local firewall and model-provider profiles.
+
+These cannot be ambient privileges. Network and assistant integrations must be declared as profiles and connected to evidence, model routing, policy, and consent.
+
+## New schema types
+
+| Schema | Purpose |
+|---|---|
+| `NetworkAccessProfile.json` | Precedence-aware user/enterprise/device/workspace network policy stack. |
+| `FirewallBindingProfile.json` | Host, user, enterprise, and cluster firewall binding plan/import profile. |
+| `MeshBindingProfile.json` | Istio/Admiral/Linkerd/Cilium/Kubernetes mesh-policy binding profile. |
+| `ExternalModelProviderProfile.json` | BYOM and enterprise model endpoint profile, including endpoint, auth reference, firewall/mesh refs, and route policy. |
+| `NativeAssistantBridgeProfile.json` | Native assistant integration profile for Apple App Intents/Siri/Shortcuts, Android, Windows, browser extensions, and future host/device bridges. |
+
+## Profile separation
+
+SourceOS must support multiple simultaneous network profiles:
+
+- corporate firewall profile;
+- workspace profile;
+- device profile;
+- user firewall profile;
+- agent/workload profile;
+- model-provider profile.
+
+Default precedence should be:
+
+```text
+enterprise -> workspace -> device -> user -> agent -> model-provider
+```
+
+A user profile may be stricter than enterprise policy, but must not override enterprise denies.
+
+## Firewall and mesh posture
+
+Mesh policy and firewall policy are complementary.
+
+Istio egress gateways route traffic through mesh-controlled exit points and allow monitoring/routing policy on traffic leaving the mesh. However, mesh sidecars can be bypassed unless external enforcement such as network policy or firewall controls prevent non-gateway egress. Therefore SourceOS models both:
+
+```text
+MeshBindingProfile + FirewallBindingProfile
+```
+
+## BYOM posture
+
+Bring-your-own-model endpoints are first-class provider profiles. They can represent user-private endpoints, enterprise-private endpoints, or cloud model providers.
+
+Rules:
+
+- endpoint auth is always a reference, never an inline token;
+- prompt egress is denied by default unless policy allows it;
+- training use is denied by default;
+- hosted fallback requires model-router and network-policy approval;
+- provider route decisions emit evidence.
+
+## Native assistant posture
+
+Apple integration should use App Intents/App Shortcuts style surfaces, not raw Siri plumbing. SourceOS capabilities should be exposed as declared intents such as:
+
+- open workroom;
+- create office artifact;
+- summarize;
+- route local model;
+- inspect evidence;
+- hand off to Agent Machine.
+
+Native assistant bridges must remain policy-gated:
+
+- local-only by default;
+- no prompt egress by default;
+- no raw app database access;
+- no side effects without confirmation;
+- cross-device handoff disabled unless explicitly granted;
+- prompt evidence should be hash-only/redacted.
+
+## Examples
+
+| Example | Purpose |
+|---|---|
+| `examples/network_access_profile.enterprise_and_user.json` | Enterprise and user profile stack with precedence. |
+| `examples/firewall_binding_profile.macos_lulu_user.json` | macOS user firewall planning profile for LuLu-style outbound control. |
+| `examples/firewall_binding_profile.enterprise_gateway.json` | Enterprise gateway firewall import/enforcement profile. |
+| `examples/mesh_binding_profile.istio_admiral_enterprise.json` | Istio/Admiral-style enterprise mesh egress profile. |
+| `examples/external_model_provider_profile.byom_openai_compatible.json` | User BYOM OpenAI-compatible endpoint profile. |
+| `examples/native_assistant_bridge_profile.apple_app_intents.json` | Apple App Intents/Siri/Shortcuts-style native bridge profile. |
+
+## Implementation owners
+
+| Repo | Role |
+|---|---|
+| `SourceOS-Linux/sourceos-spec` | Canonical network/firewall/mesh/BYOM/native assistant contracts. |
+| `SourceOS-Linux/sourceos-devtools` | Future `sourceosctl network ...` and `sourceosctl native-assistant ...` probe/plan surface. |
+| `SocioProphet/model-router` | Route external model providers and BYOM endpoints under local/enterprise policy. |
+| `SocioProphet/agentplane` | Network/model-provider/native-assistant evidence. |
+| `SocioProphet/sociosphere` | Topology validation and dependency direction. |
+| `SociOS-Linux/socios` | Opt-in orchestration where network/model/native assistant flows touch personalization workflows. |
+| `SocioProphet/guardrail-fabric` | Policy decision/evidence authority for prompt egress and side effects. |
+
+## Non-goals
+
+- Do not vendor Istio, Admiral, LuLu, Cilium, or enterprise firewall implementation here.
+- Do not store firewall credentials, VPN secrets, API keys, or model-provider tokens.
+- Do not claim a mesh policy alone prevents bypass; firewall/network policy must be modeled too.
+- Do not expose raw Apple app databases, Photos libraries, Notes stores, mail stores, browser profiles, keychains, or token stores by default.

--- a/examples/external_model_provider_profile.byom_openai_compatible.json
+++ b/examples/external_model_provider_profile.byom_openai_compatible.json
@@ -1,0 +1,36 @@
+{
+  "id": "urn:srcos:external-model-provider-profile:user-openai-compatible",
+  "type": "ExternalModelProviderProfile",
+  "specVersion": "2.2.0",
+  "name": "User BYOM OpenAI-compatible endpoint",
+  "providerClass": "openai-compatible",
+  "owner": "user",
+  "endpoint": {
+    "baseUrlRef": "secret://user/model-provider/base-url",
+    "authRef": "secret://user/model-provider/api-key",
+    "tlsPolicyRef": "urn:srcos:tls-policy:user-model-provider-default",
+    "networkAccessProfileRef": "urn:srcos:network-access-profile:enterprise-and-user-default",
+    "firewallBindingRef": "urn:srcos:firewall-binding-profile:macos-lulu-user-default",
+    "meshBindingRef": null
+  },
+  "routing": {
+    "modelRouterBindingRef": "urn:socioprophet:model-router-binding:demo-user-local-llama32",
+    "taskClasses": ["summarization", "rewrite", "office-assist", "complex-reasoning"],
+    "fallbackOrder": ["local-llama32-1b", "local-llama32-3b", "user-openai-compatible"],
+    "hostedFallbackRequiresPolicy": true
+  },
+  "policy": {
+    "promptEgressDefault": "allow-with-policy",
+    "storePrompts": false,
+    "storeCompletions": false,
+    "allowTrainingUse": false,
+    "requiresDpaOrEnterpriseTerms": false,
+    "requiresUserConsentForPersonalData": true
+  },
+  "evidence": {
+    "emitRouteDecision": true,
+    "emitNetworkDecision": true,
+    "emitProviderHealth": true,
+    "promptHashOnly": true
+  }
+}

--- a/examples/firewall_binding_profile.enterprise_gateway.json
+++ b/examples/firewall_binding_profile.enterprise_gateway.json
@@ -1,0 +1,39 @@
+{
+  "id": "urn:srcos:firewall-binding-profile:enterprise-gateway-default",
+  "type": "FirewallBindingProfile",
+  "specVersion": "2.2.0",
+  "name": "Enterprise gateway firewall binding for SourceOS workloads",
+  "bindingClass": "enterprise-gateway",
+  "mode": "import-only",
+  "owner": "enterprise",
+  "precedence": 0,
+  "conflictPolicy": "enterprise-wins",
+  "rules": [
+    {
+      "ruleId": "allow-enterprise-model-endpoint",
+      "direction": "egress",
+      "decision": "allow",
+      "subject": "sourceos-agent-machine-workloads",
+      "destination": "models.enterprise.example",
+      "ports": [443],
+      "protocols": ["tcp", "https"],
+      "reason": "Enterprise-approved private model endpoint."
+    },
+    {
+      "ruleId": "deny-unapproved-model-egress",
+      "direction": "egress",
+      "decision": "deny",
+      "subject": "sourceos-agent-machine-workloads",
+      "destination": "unapproved-external-model-providers",
+      "ports": [443],
+      "protocols": ["tcp", "https"],
+      "reason": "Corporate firewall owns external model egress approval."
+    }
+  ],
+  "evidence": {
+    "emitRulePlan": true,
+    "emitAppliedRuleReceipt": true,
+    "emitDeniedConnectionReceipt": true,
+    "redactDestinations": true
+  }
+}

--- a/examples/firewall_binding_profile.macos_lulu_user.json
+++ b/examples/firewall_binding_profile.macos_lulu_user.json
@@ -1,0 +1,39 @@
+{
+  "id": "urn:srcos:firewall-binding-profile:macos-lulu-user-default",
+  "type": "FirewallBindingProfile",
+  "specVersion": "2.2.0",
+  "name": "macOS user firewall binding for SourceOS local tools",
+  "bindingClass": "macos-lulu",
+  "mode": "plan",
+  "owner": "user",
+  "precedence": 50,
+  "conflictPolicy": "most-restrictive-wins",
+  "rules": [
+    {
+      "ruleId": "allow-local-ollama",
+      "direction": "egress",
+      "decision": "allow",
+      "subject": "sourceosctl",
+      "destination": "127.0.0.1",
+      "ports": [11434],
+      "protocols": ["tcp", "http"],
+      "reason": "Allow local model runtime probe without external network egress."
+    },
+    {
+      "ruleId": "ask-external-model-provider",
+      "direction": "egress",
+      "decision": "ask",
+      "subject": "sourceosctl",
+      "destination": "external-model-provider",
+      "ports": [443],
+      "protocols": ["tcp", "https"],
+      "reason": "External model provider access is user-visible and policy-gated."
+    }
+  ],
+  "evidence": {
+    "emitRulePlan": true,
+    "emitAppliedRuleReceipt": true,
+    "emitDeniedConnectionReceipt": true,
+    "redactDestinations": true
+  }
+}

--- a/examples/mesh_binding_profile.istio_admiral_enterprise.json
+++ b/examples/mesh_binding_profile.istio_admiral_enterprise.json
@@ -1,0 +1,36 @@
+{
+  "id": "urn:srcos:mesh-binding-profile:istio-egress-default",
+  "type": "MeshBindingProfile",
+  "specVersion": "2.2.0",
+  "name": "Istio/Admiral-style enterprise mesh egress binding",
+  "meshClass": "admiral-istio",
+  "scope": "enterprise",
+  "traffic": {
+    "egressMode": "egress-gateway",
+    "ingressMode": "gateway",
+    "allowedHosts": [
+      "models.enterprise.example",
+      "registry.enterprise.example",
+      "updates.enterprise.example"
+    ],
+    "deniedHosts": ["*"],
+    "mtlsRequired": true,
+    "externalModelEgressAllowed": false
+  },
+  "identity": {
+    "serviceAccountRef": "system:serviceaccount:sourceos:agent-machine-runner",
+    "spiffeIdRef": "spiffe://enterprise.example/sourceos/agent-machine-runner",
+    "workloadSelector": "app=sourceos-agent-machine",
+    "agentRegistryRef": "urn:socioprophet:agent-registry:agent-machine-runner"
+  },
+  "policyRefs": [
+    "urn:srcos:network-access-profile:enterprise-and-user-default",
+    "urn:srcos:firewall-binding-profile:enterprise-gateway-default"
+  ],
+  "evidence": {
+    "emitTrafficDecision": true,
+    "emitMeshPolicyRef": true,
+    "emitMtlsStatus": true,
+    "emitEgressGatewayReceipt": true
+  }
+}

--- a/examples/native_assistant_bridge_profile.apple_app_intents.json
+++ b/examples/native_assistant_bridge_profile.apple_app_intents.json
@@ -1,0 +1,69 @@
+{
+  "id": "urn:srcos:native-assistant-bridge-profile:apple-app-intents-default",
+  "type": "NativeAssistantBridgeProfile",
+  "specVersion": "2.2.0",
+  "name": "Apple App Intents bridge for SourceOS workrooms",
+  "platform": "macos",
+  "bridgeClass": "apple-app-intents",
+  "capabilities": [
+    {
+      "capabilityId": "open-workroom",
+      "operation": "open-workroom",
+      "defaultDecision": "allow-readonly",
+      "requiresUserConfirmation": false,
+      "requiresNetworkProfileRef": null,
+      "requiresModelRouteBindingRef": null,
+      "requiresAgentRegistryGrantRef": null
+    },
+    {
+      "capabilityId": "create-office-artifact",
+      "operation": "create-office-artifact",
+      "defaultDecision": "ask",
+      "requiresUserConfirmation": true,
+      "requiresNetworkProfileRef": "urn:srcos:network-access-profile:enterprise-and-user-default",
+      "requiresModelRouteBindingRef": "urn:socioprophet:model-router-binding:demo-user-local-llama32",
+      "requiresAgentRegistryGrantRef": null
+    },
+    {
+      "capabilityId": "route-local-model",
+      "operation": "route-local-model",
+      "defaultDecision": "allow-with-policy",
+      "requiresUserConfirmation": true,
+      "requiresNetworkProfileRef": "urn:srcos:network-access-profile:enterprise-and-user-default",
+      "requiresModelRouteBindingRef": "urn:socioprophet:model-router-binding:demo-user-local-llama32",
+      "requiresAgentRegistryGrantRef": null
+    }
+  ],
+  "policy": {
+    "localOnlyDefault": true,
+    "allowPromptEgress": false,
+    "allowCrossDeviceHandoff": false,
+    "allowPersonalContextRead": false,
+    "allowSideEffectsWithoutConfirmation": false,
+    "allowedAppSurfaces": ["Shortcuts", "Spotlight", "Siri", "Widgets"],
+    "deniedAppSurfaces": ["raw-mail-store", "raw-notes-db", "photos-library", "keychain", "browser-profiles"]
+  },
+  "dataBoundary": {
+    "allowedRefs": [
+      "prophet-workspace://workrooms",
+      "sourceos-office://workspace/output",
+      "agentplane://evidence"
+    ],
+    "deniedRefs": [
+      "whole-home",
+      "raw-app-stores",
+      "keychain",
+      "browser-profiles",
+      "security-material-directories"
+    ],
+    "rawAppDatabaseAccessAllowed": false,
+    "promptHashOnlyEvidence": true
+  },
+  "evidence": {
+    "emitAssistantInvocation": true,
+    "emitUserConfirmation": true,
+    "emitRouteDecision": true,
+    "emitNativeBridgeReceipt": true,
+    "redactPromptText": true
+  }
+}

--- a/examples/network_access_profile.enterprise_and_user.json
+++ b/examples/network_access_profile.enterprise_and_user.json
@@ -1,0 +1,52 @@
+{
+  "id": "urn:srcos:network-access-profile:enterprise-and-user-default",
+  "type": "NetworkAccessProfile",
+  "specVersion": "2.2.0",
+  "name": "Enterprise and user network policy stack",
+  "scope": "workspace",
+  "defaultDecision": "deny",
+  "precedence": ["enterprise", "workspace", "device", "user", "agent", "model-provider"],
+  "profiles": [
+    {
+      "profileId": "enterprise-primary-egress",
+      "profileClass": "corporate-firewall",
+      "priority": 0,
+      "defaultEgress": "allow-listed",
+      "allowDomains": [
+        "models.enterprise.example",
+        "registry.enterprise.example",
+        "updates.enterprise.example"
+      ],
+      "denyDomains": ["*"],
+      "allowCidrs": ["10.0.0.0/8", "172.16.0.0/12"],
+      "denyCidrs": [],
+      "proxyRef": "urn:srcos:proxy:enterprise-primary",
+      "firewallBindingRef": "urn:srcos:firewall-binding-profile:enterprise-gateway-default",
+      "meshBindingRef": "urn:srcos:mesh-binding-profile:istio-egress-default",
+      "modelProviderRefs": ["urn:srcos:external-model-provider-profile:enterprise-openai-compatible"],
+      "notes": "Enterprise network profile has higher precedence than user profile."
+    },
+    {
+      "profileId": "user-local-firewall",
+      "profileClass": "user-firewall",
+      "priority": 50,
+      "defaultEgress": "allow-with-prompt",
+      "allowDomains": ["localhost", "127.0.0.1"],
+      "denyDomains": [],
+      "allowCidrs": ["127.0.0.0/8"],
+      "denyCidrs": [],
+      "proxyRef": null,
+      "firewallBindingRef": "urn:srcos:firewall-binding-profile:macos-lulu-user-default",
+      "meshBindingRef": null,
+      "modelProviderRefs": ["urn:srcos:external-model-provider-profile:user-openai-compatible"],
+      "notes": "User profile can be stricter than enterprise policy but cannot override enterprise deny rules."
+    }
+  ],
+  "evidence": {
+    "emitNetworkDecision": true,
+    "emitFirewallBinding": true,
+    "emitMeshBinding": true,
+    "emitModelProviderRoute": true,
+    "redactDestinationPath": true
+  }
+}

--- a/schemas/ExternalModelProviderProfile.json
+++ b/schemas/ExternalModelProviderProfile.json
@@ -1,0 +1,62 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.srcos.ai/v2/ExternalModelProviderProfile.json",
+  "title": "ExternalModelProviderProfile",
+  "description": "SourceOS profile for enterprise, user, and BYOM model endpoints routed through Network Door, Firewall Door, Mesh Door, and model-router policy.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["id", "type", "specVersion", "name", "providerClass", "owner", "endpoint", "routing", "policy", "evidence"],
+  "properties": {
+    "id": { "type": "string", "pattern": "^urn:srcos:external-model-provider-profile:" },
+    "type": { "const": "ExternalModelProviderProfile" },
+    "specVersion": { "type": "string" },
+    "name": { "type": "string" },
+    "providerClass": { "type": "string", "enum": ["openai-compatible", "ollama-remote", "vllm", "tgi", "llama.cpp-server", "mlx-server", "azure-openai", "aws-bedrock", "google-vertex", "anthropic", "enterprise-private", "user-private", "other"] },
+    "owner": { "type": "string", "enum": ["user", "enterprise", "workspace", "tenant", "device"] },
+    "endpoint": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["baseUrlRef", "authRef"],
+      "properties": {
+        "baseUrlRef": { "type": "string", "description": "Endpoint URI or secret/config reference. Do not inline credentials." },
+        "authRef": { "type": ["string", "null"], "description": "Token Door / secret reference, never an inline token." },
+        "tlsPolicyRef": { "type": ["string", "null"] },
+        "networkAccessProfileRef": { "type": ["string", "null"] },
+        "firewallBindingRef": { "type": ["string", "null"] },
+        "meshBindingRef": { "type": ["string", "null"] }
+      }
+    },
+    "routing": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "modelRouterBindingRef": { "type": ["string", "null"] },
+        "taskClasses": { "type": "array", "items": { "type": "string" } },
+        "fallbackOrder": { "type": "array", "items": { "type": "string" } },
+        "hostedFallbackRequiresPolicy": { "type": "boolean", "default": true }
+      }
+    },
+    "policy": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "promptEgressDefault": { "type": "string", "enum": ["deny", "allow-with-policy", "allow"] },
+        "storePrompts": { "type": "boolean", "default": false },
+        "storeCompletions": { "type": "boolean", "default": false },
+        "allowTrainingUse": { "type": "boolean", "default": false },
+        "requiresDpaOrEnterpriseTerms": { "type": "boolean", "default": true },
+        "requiresUserConsentForPersonalData": { "type": "boolean", "default": true }
+      }
+    },
+    "evidence": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "emitRouteDecision": { "type": "boolean", "default": true },
+        "emitNetworkDecision": { "type": "boolean", "default": true },
+        "emitProviderHealth": { "type": "boolean", "default": true },
+        "promptHashOnly": { "type": "boolean", "default": true }
+      }
+    }
+  }
+}

--- a/schemas/FirewallBindingProfile.json
+++ b/schemas/FirewallBindingProfile.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.srcos.ai/v2/FirewallBindingProfile.json",
+  "title": "FirewallBindingProfile",
+  "description": "SourceOS firewall binding profile for host, enterprise, and cluster firewall integrations such as LuLu, pf, Windows Defender Firewall, nftables, Cilium, Kubernetes NetworkPolicy, and enterprise gateways.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["id", "type", "specVersion", "name", "bindingClass", "mode", "rules", "evidence"],
+  "properties": {
+    "id": { "type": "string", "pattern": "^urn:srcos:firewall-binding-profile:" },
+    "type": { "const": "FirewallBindingProfile" },
+    "specVersion": { "type": "string" },
+    "name": { "type": "string" },
+    "bindingClass": { "type": "string", "enum": ["macos-lulu", "macos-pf", "windows-defender-firewall", "linux-nftables", "linux-ufw", "cilium", "kubernetes-network-policy", "enterprise-gateway", "other"] },
+    "mode": { "type": "string", "enum": ["observe", "plan", "enforce", "import-only"] },
+    "owner": { "type": "string", "enum": ["user", "enterprise", "workspace", "device", "cluster"] },
+    "rules": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["ruleId", "direction", "decision", "subject", "destination"],
+        "properties": {
+          "ruleId": { "type": "string" },
+          "direction": { "type": "string", "enum": ["egress", "ingress", "both"] },
+          "decision": { "type": "string", "enum": ["allow", "deny", "ask", "log-only"] },
+          "subject": { "type": "string", "description": "Process, bundle id, container id, pod selector, service account, or workload identity." },
+          "destination": { "type": "string", "description": "Domain, CIDR, service, mesh host, or provider endpoint ref." },
+          "ports": { "type": "array", "items": { "type": "integer", "minimum": 1, "maximum": 65535 } },
+          "protocols": { "type": "array", "items": { "type": "string", "enum": ["tcp", "udp", "icmp", "http", "https", "grpc", "other"] } },
+          "reason": { "type": "string" }
+        }
+      }
+    },
+    "precedence": { "type": "integer", "minimum": 0 },
+    "conflictPolicy": { "type": "string", "enum": ["most-restrictive-wins", "enterprise-wins", "user-wins", "deny-on-conflict"] },
+    "evidence": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "emitRulePlan": { "type": "boolean", "default": true },
+        "emitAppliedRuleReceipt": { "type": "boolean", "default": true },
+        "emitDeniedConnectionReceipt": { "type": "boolean", "default": true },
+        "redactDestinations": { "type": "boolean", "default": true }
+      }
+    }
+  }
+}

--- a/schemas/MeshBindingProfile.json
+++ b/schemas/MeshBindingProfile.json
@@ -1,0 +1,50 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.srcos.ai/v2/MeshBindingProfile.json",
+  "title": "MeshBindingProfile",
+  "description": "SourceOS service-mesh binding profile for Istio, Admiral-style multi-cluster control, Linkerd, Cilium service mesh, Kubernetes NetworkPolicy adjacency, and enterprise mesh imports.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["id", "type", "specVersion", "name", "meshClass", "scope", "traffic", "identity", "evidence"],
+  "properties": {
+    "id": { "type": "string", "pattern": "^urn:srcos:mesh-binding-profile:" },
+    "type": { "const": "MeshBindingProfile" },
+    "specVersion": { "type": "string" },
+    "name": { "type": "string" },
+    "meshClass": { "type": "string", "enum": ["istio", "admiral-istio", "linkerd", "cilium-service-mesh", "kubernetes-network-policy", "enterprise-mesh", "none", "other"] },
+    "scope": { "type": "string", "enum": ["cluster", "workspace", "agent-machine", "namespace", "tenant", "enterprise"] },
+    "traffic": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "egressMode": { "type": "string", "enum": ["deny", "service-entry-allowlist", "egress-gateway", "direct-allowlist", "ambient", "enterprise-managed"] },
+        "ingressMode": { "type": "string", "enum": ["deny", "gateway", "mesh-internal", "enterprise-managed"] },
+        "allowedHosts": { "type": "array", "items": { "type": "string" } },
+        "deniedHosts": { "type": "array", "items": { "type": "string" } },
+        "mtlsRequired": { "type": "boolean", "default": true },
+        "externalModelEgressAllowed": { "type": "boolean", "default": false }
+      }
+    },
+    "identity": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "serviceAccountRef": { "type": ["string", "null"] },
+        "spiffeIdRef": { "type": ["string", "null"] },
+        "workloadSelector": { "type": ["string", "null"] },
+        "agentRegistryRef": { "type": ["string", "null"] }
+      }
+    },
+    "policyRefs": { "type": "array", "items": { "type": "string" } },
+    "evidence": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "emitTrafficDecision": { "type": "boolean", "default": true },
+        "emitMeshPolicyRef": { "type": "boolean", "default": true },
+        "emitMtlsStatus": { "type": "boolean", "default": true },
+        "emitEgressGatewayReceipt": { "type": "boolean", "default": true }
+      }
+    }
+  }
+}

--- a/schemas/NativeAssistantBridgeProfile.json
+++ b/schemas/NativeAssistantBridgeProfile.json
@@ -1,0 +1,69 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.srcos.ai/v2/NativeAssistantBridgeProfile.json",
+  "title": "NativeAssistantBridgeProfile",
+  "description": "SourceOS native assistant bridge profile for host/device assistant surfaces such as Apple App Intents, Siri/App Shortcuts, Apple Foundation Models, Android intents, Windows shell integrations, and browser/native extension bridges.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["id", "type", "specVersion", "name", "platform", "bridgeClass", "capabilities", "policy", "evidence"],
+  "properties": {
+    "id": { "type": "string", "pattern": "^urn:srcos:native-assistant-bridge-profile:" },
+    "type": { "const": "NativeAssistantBridgeProfile" },
+    "specVersion": { "type": "string" },
+    "name": { "type": "string" },
+    "platform": { "type": "string", "enum": ["macos", "ios", "ipados", "watchos", "visionos", "android", "windows", "linux", "browser", "cross-device"] },
+    "bridgeClass": { "type": "string", "enum": ["apple-app-intents", "apple-shortcuts", "apple-foundation-models", "android-intents", "windows-shell", "browser-extension", "native-messaging", "mcp", "other"] },
+    "capabilities": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["capabilityId", "operation", "defaultDecision"],
+        "properties": {
+          "capabilityId": { "type": "string" },
+          "operation": { "type": "string", "enum": ["open-workroom", "create-office-artifact", "summarize", "route-local-model", "handoff-to-agent-machine", "inspect-evidence", "search-workspace", "create-reminder", "create-note", "share-artifact", "other"] },
+          "defaultDecision": { "type": "string", "enum": ["allow-readonly", "ask", "deny", "allow-with-policy"] },
+          "requiresUserConfirmation": { "type": "boolean", "default": true },
+          "requiresNetworkProfileRef": { "type": ["string", "null"] },
+          "requiresModelRouteBindingRef": { "type": ["string", "null"] },
+          "requiresAgentRegistryGrantRef": { "type": ["string", "null"] }
+        }
+      }
+    },
+    "policy": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "localOnlyDefault": { "type": "boolean", "default": true },
+        "allowPromptEgress": { "type": "boolean", "default": false },
+        "allowCrossDeviceHandoff": { "type": "boolean", "default": false },
+        "allowPersonalContextRead": { "type": "boolean", "default": false },
+        "allowSideEffectsWithoutConfirmation": { "type": "boolean", "default": false },
+        "allowedAppSurfaces": { "type": "array", "items": { "type": "string" } },
+        "deniedAppSurfaces": { "type": "array", "items": { "type": "string" } }
+      }
+    },
+    "dataBoundary": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "allowedRefs": { "type": "array", "items": { "type": "string" } },
+        "deniedRefs": { "type": "array", "items": { "type": "string" } },
+        "rawAppDatabaseAccessAllowed": { "type": "boolean", "default": false },
+        "promptHashOnlyEvidence": { "type": "boolean", "default": true }
+      }
+    },
+    "evidence": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "emitAssistantInvocation": { "type": "boolean", "default": true },
+        "emitUserConfirmation": { "type": "boolean", "default": true },
+        "emitRouteDecision": { "type": "boolean", "default": true },
+        "emitNativeBridgeReceipt": { "type": "boolean", "default": true },
+        "redactPromptText": { "type": "boolean", "default": true }
+      }
+    }
+  }
+}

--- a/schemas/NetworkAccessProfile.json
+++ b/schemas/NetworkAccessProfile.json
@@ -1,0 +1,57 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.srcos.ai/v2/NetworkAccessProfile.json",
+  "title": "NetworkAccessProfile",
+  "description": "SourceOS Network Door profile for enterprise, user, and mesh-aware egress/ingress policy across Agent Machine, Office Plane, Local Model Door, and external model providers.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["id", "type", "specVersion", "name", "scope", "defaultDecision", "profiles", "evidence"],
+  "properties": {
+    "id": { "type": "string", "pattern": "^urn:srcos:network-access-profile:" },
+    "type": { "const": "NetworkAccessProfile" },
+    "specVersion": { "type": "string" },
+    "name": { "type": "string" },
+    "scope": { "type": "string", "enum": ["user", "enterprise", "device", "workspace", "agent-machine", "cluster"] },
+    "defaultDecision": { "type": "string", "enum": ["deny", "allow-with-policy", "ask"] },
+    "profiles": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["profileId", "profileClass", "priority", "defaultEgress"],
+        "properties": {
+          "profileId": { "type": "string" },
+          "profileClass": { "type": "string", "enum": ["user-firewall", "corporate-firewall", "mesh", "proxy", "vpn", "zero-trust", "offline"] },
+          "priority": { "type": "integer", "minimum": 0 },
+          "defaultEgress": { "type": "string", "enum": ["deny", "allow-listed", "allow-with-prompt", "allow-any"] },
+          "allowDomains": { "type": "array", "items": { "type": "string" } },
+          "denyDomains": { "type": "array", "items": { "type": "string" } },
+          "allowCidrs": { "type": "array", "items": { "type": "string" } },
+          "denyCidrs": { "type": "array", "items": { "type": "string" } },
+          "proxyRef": { "type": ["string", "null"] },
+          "firewallBindingRef": { "type": ["string", "null"] },
+          "meshBindingRef": { "type": ["string", "null"] },
+          "modelProviderRefs": { "type": "array", "items": { "type": "string" } },
+          "notes": { "type": "string" }
+        }
+      }
+    },
+    "precedence": {
+      "type": "array",
+      "items": { "type": "string", "enum": ["enterprise", "workspace", "device", "user", "agent", "model-provider"] },
+      "description": "Higher-precedence policy layers should be listed first."
+    },
+    "evidence": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "emitNetworkDecision": { "type": "boolean", "default": true },
+        "emitFirewallBinding": { "type": "boolean", "default": true },
+        "emitMeshBinding": { "type": "boolean", "default": true },
+        "emitModelProviderRoute": { "type": "boolean", "default": true },
+        "redactDestinationPath": { "type": "boolean", "default": true }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds SourceOS contracts for enterprise/user networking, firewall bindings, mesh bindings, bring-your-own-model endpoints, and native assistant bridges.

This responds to the enterprise and cross-device requirement: SourceOS must work behind corporate firewalls, user firewalls, service meshes, and native assistant surfaces without granting ambient network or device privileges.

## Changes

Adds schemas:

- `schemas/NetworkAccessProfile.json`
- `schemas/FirewallBindingProfile.json`
- `schemas/MeshBindingProfile.json`
- `schemas/ExternalModelProviderProfile.json`
- `schemas/NativeAssistantBridgeProfile.json`

Adds examples:

- `examples/network_access_profile.enterprise_and_user.json`
- `examples/firewall_binding_profile.macos_lulu_user.json`
- `examples/firewall_binding_profile.enterprise_gateway.json`
- `examples/mesh_binding_profile.istio_admiral_enterprise.json`
- `examples/external_model_provider_profile.byom_openai_compatible.json`
- `examples/native_assistant_bridge_profile.apple_app_intents.json`

Adds docs:

- `docs/contract-additions/network-assistant-model-doors.md`
- contract additions index update

## Design posture

- Separate enterprise and user network profiles.
- Enterprise deny rules have precedence over user allow rules.
- User firewall profiles may be stricter than enterprise profiles.
- BYOM endpoints are first-class `ExternalModelProviderProfile` objects.
- Endpoint auth is always a reference, never an inline secret.
- Mesh policy and firewall policy are complementary.
- Native assistant integration uses declared bridge profiles and explicit capabilities.
- Apple/Siri/Shortcuts-style integration is modeled as an App Intents bridge, not raw assistant access.
- Prompt egress and cross-device handoff are denied by default.

## Boundary

This does not vendor or implement Istio, Admiral, LuLu, Cilium, enterprise gateways, or native assistant runtimes. It defines the contract layer for downstream implementation in sourceos-devtools, model-router, AgentPlane, Sociosphere, and guardrail/policy surfaces.

## Validation

Expected validation:

```bash
python -m json.tool schemas/NetworkAccessProfile.json
python -m json.tool examples/network_access_profile.enterprise_and_user.json
```