### PR TITLE
contracts: add Mac-on-Linux polish metadata to DesktopProfile

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -8,6 +8,8 @@ This directory contains one conforming JSON example payload for each top-level s
 
 The examples are designed to tell coherent end-to-end stories. The original example set catalogs, governs, transforms, and releases a personal health dataset within an agent session. Newer SourceOS examples show a SourceOS Workstation artifact flowing from content intent through overlays, build request, release manifest, evidence bundle, catalog entry, and access profile. The control-plane examples add the local-first lifecycle proof path: a `ReleaseSet` assigned to an M2 demo device, a `BootReleaseSet` for the recovery/provisioning lane, an `EnrollmentToken` authorizing one-time recovery access, and a `Fingerprint` reporting the realized post-apply state. Compression Commons examples add an artifact-versus-baseline evaluation record that references existing governance, execution, provenance, and content-reference contracts.
 
+Desktop/workstation examples may include bounded Mac-on-Linux polish metadata. These are contract signals only: concrete implementation authority remains in `SociOS-Linux/source-os`, and the examples do not claim full macOS parity.
+
 ```text
 connector.json       ──► asset.json
                               │
@@ -188,11 +190,11 @@ These examples illustrate the shared object family used by SourceOS artifact bui
 | `schema.json` | SchemaDefinition | The schema for health observations |
 | `session_receipt.json` | SessionReceipt | Receipt for the completed agent session |
 | `session_review.json` | SessionReview | Post-session learning review |
-| `settlement_event.json` | SettlementEvent | Optional receipt-to-settlement mapping |
+| `settlement_event.json` | Optional receipt-to-settlement mapping |
 | `skill_manifest.json` | SkillManifest | The obfuscation skill manifest |
 | `telemetry_event.json` | TelemetryEvent | An informational telemetry event from the agent session |
 | `topic.json` | Topic | FogVault topic definition |
-| `topic_envelope.json` | TopicEnvelope | FogVault append-only entry envelope |
+| `topic_envelope.json` | FogVault append-only entry envelope |
 | `truth_surface.json` | TruthSurface | Truth Plane truth surface example |
 | `workflow_spec.json` | WorkflowSpec | The health-data obfuscation workflow |
 | `workorder.json` | WorkOrder | FogCompute work order |

--- a/examples/desktopprofile.json
+++ b/examples/desktopprofile.json
@@ -17,6 +17,26 @@
       "name": "SourceOS Terminal",
       "binding": "<Super>Return",
       "command": "gnome-terminal"
+    },
+    {
+      "name": "SourceOS Screenshot Screen",
+      "binding": "<Super><Shift>3",
+      "command": "mac-screenshot.sh screen"
+    },
+    {
+      "name": "SourceOS Screenshot Area",
+      "binding": "<Super><Shift>4",
+      "command": "mac-screenshot.sh area"
+    },
+    {
+      "name": "SourceOS Screenshot Interactive",
+      "binding": "<Super><Shift>5",
+      "command": "mac-screenshot.sh interactive"
+    },
+    {
+      "name": "SourceOS Screenshots Folder",
+      "binding": "<Super><Shift>6",
+      "command": "mac-screenshot.sh open-dir"
     }
   ],
   "input": {
@@ -24,5 +44,39 @@
     "compatibilityBackends": ["xremap", "kinto"],
     "gestures": "fusuma"
   },
-  "launcherProviderRef": "urn:srcos:launcher-provider:sourceos-palette"
+  "launcherProviderRef": "urn:srcos:launcher-provider:sourceos-palette",
+  "macOnLinuxPolish": {
+    "implementationAuthority": "SociOS-Linux/source-os",
+    "activeFeatures": [
+      "sourceos-palette",
+      "files-shortcut",
+      "terminal-shortcut",
+      "screenshot-shortcuts",
+      "sushi-quick-preview",
+      "finder-like-sidebar-bookmarks",
+      "bounded-gnome-appearance-defaults",
+      "fusuma-gesture-lane"
+    ],
+    "validationBackedFeatures": [
+      "shortcut-map-contract",
+      "keyboard-remap-policy",
+      "mac-polish-helper",
+      "aggregate-polish-helper",
+      "gnome-dock-extension-helper",
+      "status-json-polish-warnings",
+      "lampstand-search-lane"
+    ],
+    "proposedFeatures": [
+      "doctor-aggregate-polish-integration",
+      "richer-palette-provider-routing",
+      "mission-control-style-overview-tuning",
+      "text-editing-modifier-parity"
+    ],
+    "nonGoals": [
+      "full-macos-ui-clone",
+      "gnome-shell-fork",
+      "libadwaita-replacement",
+      "proprietary-asset-requirement"
+    ]
+  }
 }

--- a/schemas/DesktopProfile.json
+++ b/schemas/DesktopProfile.json
@@ -65,6 +65,37 @@
     "launcherProviderRef": {
       "type": ["string", "null"],
       "description": "Optional reference to the primary LauncherProvider."
+    },
+    "macOnLinuxPolish": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Optional bounded Mac-on-Linux polish metadata. This records active and future workstation polish signals without claiming full macOS parity.",
+      "properties": {
+        "implementationAuthority": {
+          "type": "string",
+          "description": "Repository or authority responsible for concrete realization."
+        },
+        "activeFeatures": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 },
+          "description": "Currently active / implemented polish signals."
+        },
+        "validationBackedFeatures": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 },
+          "description": "Signals backed by helper or CI validation surfaces."
+        },
+        "proposedFeatures": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 },
+          "description": "Future or proposed signals that must not be counted as delivered."
+        },
+        "nonGoals": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 },
+          "description": "Explicit non-goals for this desktop profile."
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
Closes #80.

What changed:
- Added optional `macOnLinuxPolish` metadata to `schemas/DesktopProfile.json`.
- Updated `examples/desktopprofile.json` with active, validation-backed, proposed, and non-goal Mac-on-Linux polish signals.
- Updated `examples/README.md` to clarify that concrete implementation authority remains in `SociOS-Linux/source-os` and that this is not a full macOS parity claim.

Validation evidence:
- `python3 -m json.tool examples/workstationprofile.json >/dev/null`
- `python3 -m json.tool examples/desktopprofile.json >/dev/null`
- `python3 -m json.tool schemas/DesktopProfile.json >/dev/null`

Known gaps:
- This is a contract/example alignment PR only.
- Runtime implementation remains in `SociOS-Linux/source-os`.

Non-goals preserved:
- No implementation repos changed.
- No full macOS parity claim.
- No unrelated contract families changed.