### PR TITLE
Add Agent Machine model carry semantic catalog slices

### DIFF
--- a/schemas/agent-machine-model-carry-catalog.md
+++ b/schemas/agent-machine-model-carry-catalog.md
@@ -1,0 +1,27 @@
+# Agent Machine / Model Carry Schema Catalog
+
+Status: additive catalog slice
+
+This catalog records the SourceOS projection schemas added for the Prophet Intelligence Foundry runtime path. It is intentionally narrower than the global `schemas/README.md` catalog so that fast-moving schema additions can be reviewed independently before the full catalog is regenerated.
+
+| File | Type | URN prefix | Plane |
+| --- | --- | --- | --- |
+| `SourceOSModelCarryRef.json` | `SourceOSModelCarryRef` | `urn:srcos:model-carry-ref:` | SourceOS model carry |
+| `InferenceProvider.json` | `InferenceProvider` | `urn:srcos:inference-provider:` | Agent Machine runtime |
+| `ModelResidency.json` | `ModelResidency` | `urn:srcos:model-residency:` | Agent Machine runtime evidence |
+| `PlacementFact.json` | `PlacementFact` | `urn:srcos:placement-fact:` | Placement / scheduling facts |
+| `AgentMachineReceipt.json` | `AgentMachineReceipt` | `urn:srcos:agent-machine-receipt:` | Runtime receipts / evidence |
+
+## Cross-repo authority
+
+| Object | Authoritative producer | Primary consumer |
+| --- | --- | --- |
+| `SourceOSModelCarryRef` | `SourceOS-Linux/sourceos-model-carry` | `SocioProphet/model-router`, `SourceOS-Linux/agent-machine` |
+| `InferenceProvider` | `SourceOS-Linux/agent-machine` | `SocioProphet/model-router`, `SocioProphet/agentplane` |
+| `ModelResidency` | `SourceOS-Linux/agent-machine` | `SocioProphet/model-router`, `SocioProphet/policy-fabric` |
+| `PlacementFact` | `SourceOS-Linux/agent-machine` | `SocioProphet/agentplane`, `SocioProphet/policy-fabric` |
+| `AgentMachineReceipt` | `SourceOS-Linux/agent-machine` | `SocioProphet/agentplane`, `SocioProphet/model-governance-ledger` |
+
+## Boundary rule
+
+These schemas do not authorize runtime execution by themselves. Authorization remains a PolicyDecision / CapabilityToken concern. Agent Machine emits facts and receipts; AgentPlane owns run lifecycle; model-router owns routing; sourceos-model-carry owns approved carry references; model-governance-ledger owns release and promotion evidence.

--- a/semantic/README.md
+++ b/semantic/README.md
@@ -11,6 +11,22 @@ This directory provides the JSON-LD and Hydra semantic overlay for the SourceOS/
 | `context.jsonld` | JSON-LD `@context` mapping schema type names to stable IRIs under `https://schemas.srcos.ai/v2/` |
 | `hydra.jsonld` | A `hydra:ApiDocumentation` document describing the REST API's supported classes and operations |
 | `fog-vocabulary.jsonld` | Additive fog vocabulary seed for FogVault / FogCompute types and key predicates |
+| `agent-machine-model-carry-context.jsonld` | Additive context slice for SourceOS model carry and Agent Machine runtime facts/receipts |
+| `agent-machine-model-carry-hydra.jsonld` | Additive Hydra slice for SourceOS model carry and Agent Machine runtime classes |
+
+---
+
+## Recent additions — Agent Machine / Model Carry vocabulary
+
+The Agent Machine / Model Carry slice currently contributes an additive semantic vocabulary covering:
+
+- `SourceOSModelCarryRef`
+- `InferenceProvider`
+- `ModelResidency`
+- `PlacementFact`
+- `AgentMachineReceipt`
+
+This vocabulary is intentionally staged as additive slice files so it can be reviewed independently before being folded into the global `context.jsonld` and `hydra.jsonld` files.
 
 ---
 

--- a/semantic/agent-machine-model-carry-context.jsonld
+++ b/semantic/agent-machine-model-carry-context.jsonld
@@ -1,0 +1,64 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "srcos": "https://schemas.srcos.ai/v2/",
+    "prov": "http://www.w3.org/ns/prov#",
+    "id": "@id",
+    "type": "@type",
+
+    "SourceOSModelCarryRef": "srcos:SourceOSModelCarryRef",
+    "InferenceProvider": "srcos:InferenceProvider",
+    "ModelResidency": "srcos:ModelResidency",
+    "PlacementFact": "srcos:PlacementFact",
+    "AgentMachineReceipt": "srcos:AgentMachineReceipt",
+
+    "modelRef": { "@id": "srcos:modelRef", "@type": "@id" },
+    "governanceRef": { "@id": "srcos:governanceRef", "@type": "@id" },
+    "routerProfileRef": { "@id": "srcos:routerProfileRef", "@type": "@id" },
+    "releaseSetRefs": { "@id": "srcos:releaseSetRefs", "@type": "@id" },
+    "launchProfileRefs": { "@id": "srcos:launchProfileRefs", "@type": "@id" },
+    "fallbackRefs": { "@id": "srcos:fallbackRefs", "@type": "@id" },
+    "carryPolicy": "srcos:carryPolicy",
+    "cachePolicy": "srcos:cachePolicy",
+    "mutableModelState": "srcos:mutableModelState",
+
+    "providerClass": "srcos:providerClass",
+    "endpointMode": "srcos:endpointMode",
+    "executionProfile": "srcos:executionProfile",
+    "trustPosture": "srcos:trustPosture",
+    "supportedModalities": "srcos:supportedModalities",
+    "openAICompatible": "srcos:openAICompatible",
+    "requiresNetwork": "srcos:requiresNetwork",
+
+    "machineRef": { "@id": "srcos:machineRef", "@type": "@id" },
+    "modelCarryRef": { "@id": "srcos:modelCarryRef", "@type": "@id" },
+    "providerRef": { "@id": "srcos:providerRef", "@type": "@id" },
+    "residencyState": "srcos:residencyState",
+    "quantization": "srcos:quantization",
+    "bytesOnDisk": "srcos:bytesOnDisk",
+    "cacheTier": "srcos:cacheTier",
+    "observedAt": "srcos:observedAt",
+
+    "hardware": "srcos:hardware",
+    "isolation": "srcos:isolation",
+    "modelResidencyRefs": { "@id": "srcos:modelResidencyRefs", "@type": "@id" },
+    "providerRefs": { "@id": "srcos:providerRefs", "@type": "@id" },
+    "cacheNotes": "srcos:cacheNotes",
+
+    "receiptClass": "srcos:receiptClass",
+    "issuedAt": "srcos:issuedAt",
+    "taskRef": { "@id": "srcos:taskRef", "@type": "@id" },
+    "agentPodRef": { "@id": "srcos:agentPodRef", "@type": "@id" },
+    "placementFactRefs": { "@id": "srcos:placementFactRefs", "@type": "@id" },
+    "inferenceProviderRefs": { "@id": "srcos:inferenceProviderRefs", "@type": "@id" },
+    "policyDecisionRef": { "@id": "srcos:policyDecisionRef", "@type": "@id" },
+    "verdict": "srcos:verdict",
+    "metrics": "srcos:metrics",
+    "evidenceHash": "srcos:evidenceHash",
+    "evidenceRefs": { "@id": "srcos:evidenceRefs", "@type": "@id" },
+
+    "wasGeneratedBy": { "@id": "prov:wasGeneratedBy", "@type": "@id" },
+    "used": { "@id": "prov:used", "@type": "@id" },
+    "wasDerivedFrom": { "@id": "prov:wasDerivedFrom", "@type": "@id" }
+  }
+}

--- a/semantic/agent-machine-model-carry-hydra.jsonld
+++ b/semantic/agent-machine-model-carry-hydra.jsonld
@@ -1,0 +1,59 @@
+{
+  "@context": {
+    "srcos": "https://schemas.srcos.ai/v2/",
+    "hydra": "http://www.w3.org/ns/hydra/core#",
+    "id": "@id",
+    "type": "@type",
+    "SourceOSModelCarryRef": "srcos:SourceOSModelCarryRef",
+    "InferenceProvider": "srcos:InferenceProvider",
+    "ModelResidency": "srcos:ModelResidency",
+    "PlacementFact": "srcos:PlacementFact",
+    "AgentMachineReceipt": "srcos:AgentMachineReceipt"
+  },
+  "@id": "https://api.srcos.local/v2/agent-machine-model-carry",
+  "@type": "hydra:ApiDocumentation",
+  "hydra:title": "Agent Machine / Model Carry Semantic Slice",
+  "hydra:description": "Additive Hydra vocabulary seed for SourceOS model carry references, Agent Machine provider facts, model residency, placement facts, and runtime receipts.",
+  "hydra:supportedClass": [
+    {
+      "@id": "srcos:SourceOSModelCarryRef",
+      "hydra:title": "SourceOSModelCarryRef",
+      "hydra:description": "Approved on-device reference to a governed model or model-service profile carried by SourceOS without embedding mutable model state.",
+      "hydra:supportedOperation": [
+        { "hydra:method": "POST", "hydra:title": "upsertSourceOSModelCarryRef", "hydra:description": "Creates or updates an approved SourceOS model carry reference." }
+      ]
+    },
+    {
+      "@id": "srcos:InferenceProvider",
+      "hydra:title": "InferenceProvider",
+      "hydra:description": "Backend-neutral local, clustered, or governed remote inference provider description.",
+      "hydra:supportedOperation": [
+        { "hydra:method": "POST", "hydra:title": "upsertInferenceProvider", "hydra:description": "Creates or updates an inference provider description." }
+      ]
+    },
+    {
+      "@id": "srcos:ModelResidency",
+      "hydra:title": "ModelResidency",
+      "hydra:description": "Point-in-time evidence that a governed model reference is available, cached, loaded, warm, pinned, evictable, or unavailable on an Agent Machine.",
+      "hydra:supportedOperation": [
+        { "hydra:method": "POST", "hydra:title": "recordModelResidency", "hydra:description": "Records observed model residency evidence." }
+      ]
+    },
+    {
+      "@id": "srcos:PlacementFact",
+      "hydra:title": "PlacementFact",
+      "hydra:description": "Machine-local scheduling and policy fact for model, agent, cache, isolation, and runtime placement decisions.",
+      "hydra:supportedOperation": [
+        { "hydra:method": "POST", "hydra:title": "recordPlacementFact", "hydra:description": "Records an Agent Machine placement fact." }
+      ]
+    },
+    {
+      "@id": "srcos:AgentMachineReceipt",
+      "hydra:title": "AgentMachineReceipt",
+      "hydra:description": "Runtime evidence emitted by Agent Machine after probing, placement, execution, cache reuse, model load/unload, or policy-mediated side effects.",
+      "hydra:supportedOperation": [
+        { "hydra:method": "POST", "hydra:title": "recordAgentMachineReceipt", "hydra:description": "Records an Agent Machine runtime receipt." }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds catalog and semantic discoverability for the Agent Machine / Model Carry projection schemas:

- `schemas/agent-machine-model-carry-catalog.md`
- `semantic/agent-machine-model-carry-context.jsonld`
- `semantic/agent-machine-model-carry-hydra.jsonld`
- `semantic/README.md` update

## Notes

This follows PR #89, which added the core projection schemas and examples. This change is additive documentation and JSON-LD/Hydra vocabulary only; it does not change runtime behavior.