### PR TITLE
Define agent harness execution receipt boundary

### DIFF
--- a/.github/workflows/agent-harness-execution-receipts.yml
+++ b/.github/workflows/agent-harness-execution-receipts.yml
@@ -1,0 +1,37 @@
+name: Agent Harness Execution Receipts
+
+on:
+  pull_request:
+    paths:
+      - 'docs/agent-harness-execution-receipts.md'
+      - 'schemas/AgentHarnessExecutionReceipts.json'
+      - 'examples/agent-harness-execution-receipts.example.json'
+      - 'tools/validate_agent_harness_execution_receipts.py'
+      - '.github/workflows/agent-harness-execution-receipts.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'docs/agent-harness-execution-receipts.md'
+      - 'schemas/AgentHarnessExecutionReceipts.json'
+      - 'examples/agent-harness-execution-receipts.example.json'
+      - 'tools/validate_agent_harness_execution_receipts.py'
+      - '.github/workflows/agent-harness-execution-receipts.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  validate-agent-harness-execution-receipts:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Validate Agent Harness execution receipts
+        run: python3 tools/validate_agent_harness_execution_receipts.py

--- a/docs/agent-harness-execution-receipts.md
+++ b/docs/agent-harness-execution-receipts.md
@@ -1,0 +1,215 @@
+# Agent Harness Execution Receipt Boundary
+
+Status: v0.1 planning baseline  
+Owner plane: SourceOS specification / local runtime contracts  
+Runtime producers: SourceOS Agent Machine, BearBrowser, TurtleTerm, agent-term, sourceos-shell, workstation contracts  
+Consumers: AgentPlane, Policy Fabric, Memory Mesh, SCOPE-D, Delivery Excellence, SocioSphere
+
+## Purpose
+
+The Aden/Hive lessons are not limited to development workflows. They apply to local-first execution, host/runtime admission, browser actions, terminal commands, model carry, credential posture, offline operation, user-space boundaries, and customer-safe proof of work.
+
+SourceOS must define the receipt boundary for governed local execution so every agent harness action can be measured and audited without turning Delivery Excellence into a runtime or Policy Fabric into an implementation repo.
+
+## Boundary
+
+SourceOS spec owns the neutral contract vocabulary for:
+
+- local agent runtime activation
+- Agent Machine receipts
+- model carry references
+- shell and terminal receipts
+- browser action receipts
+- local-first service manifests
+- host mutation boundaries
+- network profile and offline/local-only posture
+- credential-use evidence
+- artifact and download manifests
+- replay/reconstruction pointers
+
+SourceOS spec does not own:
+
+- AgentPlane graph execution
+- Delivery Excellence scoreboards and KPIs
+- Policy Fabric gate decisions
+- Memory Mesh recall/writeback runtime
+- BearBrowser or TurtleTerm product implementation
+- SCOPE-D security exercises
+
+## Required receipt family
+
+### LocalAgentRuntimeReceipt
+
+Records local agent runtime activation and execution posture.
+
+Required semantics:
+
+- receipt id
+- runtime profile
+- agent identity ref
+- policy admission ref
+- activation decision ref
+- model carry refs
+- memory mount refs
+- network profile
+- filesystem scopes
+- secret scopes
+- host mutation policy
+- started/stopped timestamps
+- exit state
+- AgentPlane run/session refs
+
+### ShellReceiptEvent
+
+Records a terminal or shell action.
+
+Required semantics:
+
+- command id
+- command hash
+- working directory
+- actor/agent ref
+- environment profile
+- stdin/stdout/stderr pointers
+- exit code
+- file mutation summary
+- policy decision ref
+- replay eligibility
+
+### BrowserActionReceipt
+
+Records a browser action through BearBrowser or compatible governed browser surface.
+
+Required semantics:
+
+- browser session ref
+- URL/domain
+- action type
+- credential-use flag
+- upload/download refs
+- screenshot or DOM/action pointer
+- policy decision ref
+- side-effect class
+- replay/simulation eligibility
+
+### ModelCarryRouteReceipt
+
+Records local/cloud model routing used by a local runtime.
+
+Required semantics:
+
+- model profile ref
+- provider ref
+- residency class
+- privacy class
+- route decision ref
+- fallback behavior
+- cost class
+- policy decision ref
+- prompt/output hash refs when policy permits
+
+### HostMutationBoundaryReceipt
+
+Records whether a run attempted or performed host mutation.
+
+Required semantics:
+
+- mutation class
+- target scope
+- dry-run/live-run mode
+- approval ref
+- policy decision ref
+- rollback ref
+- mutated host flag
+- denied operation refs
+
+### DownloadArtifactReceipt
+
+Records downloads or generated files produced by browser, terminal, or agent runtime surfaces.
+
+Required semantics:
+
+- artifact ref
+- source URL or producer ref
+- sha256
+- media type
+- size
+- quarantine state
+- scan refs
+- retention class
+- Memory Mesh artifact pointer ref
+
+## Delivery Excellence projection
+
+Delivery Excellence consumes only derived metrics/readouts unless the relevant evidence is explicitly approved for broader visibility.
+
+Projection examples:
+
+- local runtime activation success/failure
+- shell command success/failure
+- browser action success/failure
+- host mutation denied/approved/performed
+- credential-use event count
+- offline/local-only compliance
+- artifact quarantine count
+- replay eligibility count
+- policy-blocked action count
+- customer-safe proof of work
+
+## Policy Fabric integration
+
+Every local execution receipt should be able to cite policy decisions for:
+
+- runtime admission
+- network profile
+- filesystem scope
+- secret scope
+- model route
+- browser side effect
+- terminal side effect
+- host mutation
+- artifact retention
+- credential use
+
+Fail closed when controlled actions lack a required policy decision ref.
+
+## AgentPlane integration
+
+AgentPlane should reference SourceOS receipts in `EvidencePack`, `RunArtifact`, `ReplayArtifact`, `SessionEnvelope`, and `PromotionGate` artifacts.
+
+Receipts are not merely logs. They are replay/proof inputs that can be sealed, hashed, redacted, and projected into Delivery Excellence metrics.
+
+## Memory Mesh integration
+
+Large outputs, browser screenshots, DOM captures, terminal transcripts, downloads, generated artifacts, and redacted payloads should be moved behind Memory Mesh `ArtifactPointer` refs whenever they exceed policy or size thresholds.
+
+## SCOPE-D integration
+
+SCOPE-D should validate these receipt classes for:
+
+- malicious command injection
+- browser automation abuse
+- credential exfiltration
+- artifact spoofing
+- download quarantine bypass
+- local service exposure
+- host mutation bypass
+- memory poisoning through local receipts
+
+## Non-negotiables
+
+- Host mutation must be explicit and policy-referenced.
+- Browser and terminal side effects require receipts.
+- Credential use is a first-class evidence event.
+- Offline/local-only mode must be provable.
+- Artifact pointers must be digest-addressed.
+- Delivery Excellence receives controlled projections, not raw secrets or uncontrolled logs.
+- Customer-safe readouts must not expose raw local telemetry without redaction and policy approval.
+
+## Initial implementation path
+
+1. Add schemas/examples for `LocalAgentRuntimeReceipt`, `BrowserActionReceipt`, `HostMutationBoundaryReceipt`, and `DownloadArtifactReceipt`.
+2. Align existing `ShellReceiptEvent`, `AgentMachineReceipt`, model carry, OpsHistory, and BearHistory schemas to this boundary.
+3. Require AgentPlane evidence packs to cite SourceOS receipt refs for local execution.
+4. Require Delivery Excellence projections for local execution success, host mutation posture, credential-use counts, and replay eligibility.
+5. Require SCOPE-D synthetic checks for browser/terminal/host-mutation abuse cases.

--- a/examples/agent-harness-execution-receipts.example.json
+++ b/examples/agent-harness-execution-receipts.example.json
@@ -1,0 +1,63 @@
+{
+  "schemaVersion": "v0.1",
+  "kind": "AgentHarnessExecutionReceipts",
+  "localAgentRuntimeReceipt": {
+    "receiptId": "local-runtime-agent-harness-baseline-v0.1",
+    "runtimeProfile": "sourceos-local-agent-runtime",
+    "agentIdentityRef": "agent-registry://agent/agent-harness-baseline",
+    "policyAdmissionRef": "github://SocioProphet/policy-fabric/pull/60",
+    "activationDecisionRef": "sourceos://activation/agent-harness-baseline",
+    "modelCarryRefs": ["sourceos://model-carry/local-default"],
+    "memoryMountRefs": ["github://SocioProphet/memory-mesh/pull/23"],
+    "networkProfile": "local-only",
+    "filesystemScopes": ["workspace://SocioProphet/agentplane"],
+    "secretScopes": [],
+    "hostMutationPolicy": "dry-run-only",
+    "agentplaneRunRef": "github://SocioProphet/agentplane/pull/107",
+    "exitState": "planned"
+  },
+  "shellReceiptEvent": {
+    "commandId": "command-validate-agent-harness-runtime-contracts",
+    "commandHash": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    "workingDirectory": "~/dev/agentplane",
+    "actorRef": "github://mdheller",
+    "environmentProfile": "sourceos-local-dev",
+    "stdoutPointerRef": "artifact://sha256/cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+    "stderrPointerRef": "artifact://sha256/dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+    "exitCode": 0,
+    "fileMutationSummary": "no host mutation",
+    "policyDecisionRef": "github://SocioProphet/policy-fabric/pull/60",
+    "replayEligible": true
+  },
+  "browserActionReceipt": {
+    "browserSessionRef": "bearbrowser://session/agent-harness-baseline",
+    "url": "https://github.com/SocioProphet/delivery-excellence/pull/9",
+    "actionType": "navigate",
+    "credentialUse": false,
+    "artifactPointerRefs": [],
+    "policyDecisionRef": "github://SocioProphet/policy-fabric/pull/60",
+    "sideEffectClass": "read-only",
+    "replayEligible": true
+  },
+  "hostMutationBoundaryReceipt": {
+    "mutationClass": "none",
+    "targetScope": "local-workspace",
+    "mode": "dry-run",
+    "approvalRef": "",
+    "policyDecisionRef": "github://SocioProphet/policy-fabric/pull/60",
+    "rollbackRef": "",
+    "mutatedHost": false,
+    "deniedOperationRefs": []
+  },
+  "downloadArtifactReceipt": {
+    "artifactRef": "artifact://sha256/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+    "sourceRef": "github://SocioProphet/delivery-excellence-automation/pull/7",
+    "sha256": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+    "mediaType": "application/json",
+    "sizeBytes": 1024,
+    "quarantineState": "not-required",
+    "scanRefs": [],
+    "retentionClass": "run-retained",
+    "memoryMeshPointerRef": "github://SocioProphet/memory-mesh/pull/23"
+  }
+}

--- a/schemas/AgentHarnessExecutionReceipts.json
+++ b/schemas/AgentHarnessExecutionReceipts.json
@@ -1,0 +1,96 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://sourceos.dev/schemas/AgentHarnessExecutionReceipts.json",
+  "title": "AgentHarnessExecutionReceipts",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schemaVersion", "kind", "localAgentRuntimeReceipt", "shellReceiptEvent", "browserActionReceipt", "hostMutationBoundaryReceipt", "downloadArtifactReceipt"],
+  "properties": {
+    "schemaVersion": { "const": "v0.1" },
+    "kind": { "const": "AgentHarnessExecutionReceipts" },
+    "localAgentRuntimeReceipt": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["receiptId", "runtimeProfile", "agentIdentityRef", "policyAdmissionRef", "activationDecisionRef", "networkProfile", "filesystemScopes", "hostMutationPolicy", "agentplaneRunRef"],
+      "properties": {
+        "receiptId": { "type": "string" },
+        "runtimeProfile": { "type": "string" },
+        "agentIdentityRef": { "type": "string" },
+        "policyAdmissionRef": { "type": "string" },
+        "activationDecisionRef": { "type": "string" },
+        "modelCarryRefs": { "type": "array", "items": { "type": "string" } },
+        "memoryMountRefs": { "type": "array", "items": { "type": "string" } },
+        "networkProfile": { "type": "string" },
+        "filesystemScopes": { "type": "array", "items": { "type": "string" } },
+        "secretScopes": { "type": "array", "items": { "type": "string" } },
+        "hostMutationPolicy": { "type": "string", "enum": ["deny", "dry-run-only", "approval-required", "preapproved"] },
+        "agentplaneRunRef": { "type": "string" },
+        "exitState": { "type": "string", "enum": ["planned", "running", "completed", "failed", "cancelled"] }
+      }
+    },
+    "shellReceiptEvent": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["commandId", "commandHash", "workingDirectory", "actorRef", "environmentProfile", "exitCode", "policyDecisionRef", "replayEligible"],
+      "properties": {
+        "commandId": { "type": "string" },
+        "commandHash": { "type": "string" },
+        "workingDirectory": { "type": "string" },
+        "actorRef": { "type": "string" },
+        "environmentProfile": { "type": "string" },
+        "stdoutPointerRef": { "type": "string" },
+        "stderrPointerRef": { "type": "string" },
+        "exitCode": { "type": "integer" },
+        "fileMutationSummary": { "type": "string" },
+        "policyDecisionRef": { "type": "string" },
+        "replayEligible": { "type": "boolean" }
+      }
+    },
+    "browserActionReceipt": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["browserSessionRef", "url", "actionType", "credentialUse", "policyDecisionRef", "sideEffectClass", "replayEligible"],
+      "properties": {
+        "browserSessionRef": { "type": "string" },
+        "url": { "type": "string" },
+        "actionType": { "type": "string", "enum": ["navigate", "click", "type", "extract", "screenshot", "download", "upload", "form-submit", "login", "credential-use", "account-setting-change", "message-send", "purchase-or-order", "ticket-or-record-create"] },
+        "credentialUse": { "type": "boolean" },
+        "artifactPointerRefs": { "type": "array", "items": { "type": "string" } },
+        "policyDecisionRef": { "type": "string" },
+        "sideEffectClass": { "type": "string", "enum": ["none", "read-only", "external-write", "credential", "download", "upload"] },
+        "replayEligible": { "type": "boolean" }
+      }
+    },
+    "hostMutationBoundaryReceipt": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["mutationClass", "targetScope", "mode", "policyDecisionRef", "mutatedHost"],
+      "properties": {
+        "mutationClass": { "type": "string" },
+        "targetScope": { "type": "string" },
+        "mode": { "type": "string", "enum": ["dry-run", "live"] },
+        "approvalRef": { "type": "string" },
+        "policyDecisionRef": { "type": "string" },
+        "rollbackRef": { "type": "string" },
+        "mutatedHost": { "type": "boolean" },
+        "deniedOperationRefs": { "type": "array", "items": { "type": "string" } }
+      }
+    },
+    "downloadArtifactReceipt": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["artifactRef", "sha256", "mediaType", "sizeBytes", "quarantineState", "retentionClass", "memoryMeshPointerRef"],
+      "properties": {
+        "artifactRef": { "type": "string" },
+        "sourceRef": { "type": "string" },
+        "sha256": { "type": "string" },
+        "mediaType": { "type": "string" },
+        "sizeBytes": { "type": "integer" },
+        "quarantineState": { "type": "string", "enum": ["not-required", "quarantined", "released", "blocked"] },
+        "scanRefs": { "type": "array", "items": { "type": "string" } },
+        "retentionClass": { "type": "string", "enum": ["ephemeral", "run-retained", "customer-proof-retained"] },
+        "memoryMeshPointerRef": { "type": "string" }
+      }
+    }
+  }
+}

--- a/tools/validate_agent_harness_execution_receipts.py
+++ b/tools/validate_agent_harness_execution_receipts.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""Validate SourceOS Agent Harness execution receipt examples.
+
+Uses only the Python standard library and implements the small JSON Schema subset
+used by schemas/AgentHarnessExecutionReceipts.json: required, properties,
+additionalProperties=false, const, enum, primitive type checks, arrays, and
+nested object properties.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+SCHEMA = ROOT / "schemas" / "AgentHarnessExecutionReceipts.json"
+EXAMPLE = ROOT / "examples" / "agent-harness-execution-receipts.example.json"
+
+
+class ValidationError(Exception):
+    pass
+
+
+def load_json(path: Path) -> Any:
+    try:
+        with path.open("r", encoding="utf-8") as handle:
+            return json.load(handle)
+    except FileNotFoundError as exc:
+        raise ValidationError(f"missing file: {path}") from exc
+    except json.JSONDecodeError as exc:
+        raise ValidationError(f"invalid json in {path}: {exc}") from exc
+
+
+def json_type_name(value: Any) -> str:
+    if value is None:
+        return "null"
+    if isinstance(value, bool):
+        return "boolean"
+    if isinstance(value, int) and not isinstance(value, bool):
+        return "integer"
+    if isinstance(value, float):
+        return "number"
+    if isinstance(value, str):
+        return "string"
+    if isinstance(value, list):
+        return "array"
+    if isinstance(value, dict):
+        return "object"
+    return type(value).__name__
+
+
+def type_matches(value: Any, expected: str) -> bool:
+    actual = json_type_name(value)
+    if expected == "number":
+        return actual in {"integer", "number"}
+    return actual == expected
+
+
+def validate(schema: dict[str, Any], value: Any, path: str = "$") -> None:
+    if "const" in schema and value != schema["const"]:
+        raise ValidationError(f"{path}: expected const {schema['const']!r}, got {value!r}")
+
+    if "enum" in schema and value not in schema["enum"]:
+        raise ValidationError(f"{path}: {value!r} not in enum {schema['enum']!r}")
+
+    expected_type = schema.get("type")
+    if expected_type is not None:
+        expected_types = expected_type if isinstance(expected_type, list) else [expected_type]
+        if not any(type_matches(value, item) for item in expected_types):
+            raise ValidationError(
+                f"{path}: expected type {expected_types!r}, got {json_type_name(value)!r}"
+            )
+
+    if isinstance(value, dict):
+        required = schema.get("required", [])
+        for key in required:
+            if key not in value:
+                raise ValidationError(f"{path}: missing required property {key!r}")
+
+        properties = schema.get("properties", {})
+        if schema.get("additionalProperties") is False:
+            extra = sorted(set(value) - set(properties))
+            if extra:
+                raise ValidationError(f"{path}: unexpected properties {extra!r}")
+
+        additional = schema.get("additionalProperties")
+        for key, item in value.items():
+            child_schema = properties.get(key)
+            if child_schema is None and isinstance(additional, dict):
+                child_schema = additional
+            if child_schema is not None:
+                validate(child_schema, item, f"{path}.{key}")
+
+    if isinstance(value, list):
+        item_schema = schema.get("items")
+        if item_schema is not None:
+            for index, item in enumerate(value):
+                validate(item_schema, item, f"{path}[{index}]")
+
+
+def semantic_checks(example: dict[str, Any]) -> None:
+    runtime = example["localAgentRuntimeReceipt"]
+    if runtime["networkProfile"] not in {"local-only", "offline", "corporate-firewall", "approved-internet"}:
+        raise ValidationError("localAgentRuntimeReceipt.networkProfile must be an allowed SourceOS posture")
+    if runtime["hostMutationPolicy"] == "preapproved" and not runtime.get("policyAdmissionRef"):
+        raise ValidationError("preapproved host mutation requires policy admission ref")
+
+    shell = example["shellReceiptEvent"]
+    if shell["exitCode"] != 0 and shell["replayEligible"]:
+        raise ValidationError("failed shell command should not be marked replayEligible in the baseline example")
+
+    browser = example["browserActionReceipt"]
+    if browser["credentialUse"] and browser["sideEffectClass"] != "credential":
+        raise ValidationError("credentialUse=true requires sideEffectClass=credential")
+
+    mutation = example["hostMutationBoundaryReceipt"]
+    if mutation["mutatedHost"] and mutation["mode"] != "live":
+        raise ValidationError("mutatedHost=true requires mode=live")
+    if mutation["mode"] == "live" and not mutation.get("approvalRef"):
+        raise ValidationError("live host mutation requires approvalRef")
+
+    artifact = example["downloadArtifactReceipt"]
+    if not artifact["artifactRef"].startswith("artifact://sha256/"):
+        raise ValidationError("downloadArtifactReceipt.artifactRef must use artifact://sha256/<digest>")
+    if artifact["sha256"] not in artifact["artifactRef"]:
+        raise ValidationError("downloadArtifactReceipt.artifactRef must contain the declared sha256 digest")
+
+
+def main() -> int:
+    try:
+        schema = load_json(SCHEMA)
+        example = load_json(EXAMPLE)
+        validate(schema, example)
+        semantic_checks(example)
+    except ValidationError as exc:
+        print(f"Agent Harness execution receipts validation failed: {exc}", file=sys.stderr)
+        return 1
+
+    print(f"ok: {EXAMPLE.relative_to(ROOT)} validates against {SCHEMA.relative_to(ROOT)}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Adds the SourceOS specification boundary and first machine-checkable schema/example/validator set for agent harness execution receipts.

This makes local-first runtime, browser, terminal, model carry, credential, host mutation, download/artifact, and replay proof signals consumable by AgentPlane, Policy Fabric, Memory Mesh, SCOPE-D, and Delivery Excellence without moving implementation or scoreboards into the spec repo.

## Scope

- Adds `docs/agent-harness-execution-receipts.md`.
- Adds `schemas/AgentHarnessExecutionReceipts.json`.
- Adds `examples/agent-harness-execution-receipts.example.json`.
- Adds `tools/validate_agent_harness_execution_receipts.py`.
- Adds focused CI workflow `.github/workflows/agent-harness-execution-receipts.yml`.
- Defines receipt semantics for `LocalAgentRuntimeReceipt`, `ShellReceiptEvent`, `BrowserActionReceipt`, `ModelCarryRouteReceipt`, `HostMutationBoundaryReceipt`, and `DownloadArtifactReceipt`.
- Defines Delivery Excellence projections for local runtime success, browser/terminal actions, host mutation posture, credential use, offline/local-only compliance, and replay eligibility.
- Defines Policy Fabric, AgentPlane, Memory Mesh, and SCOPE-D integration expectations.

## Validation

- Branch diff is 5 commits ahead, 9 behind current `main`; update/rebase before merge.
- Changed files are limited to docs, schema, example, validator, and focused workflow.
- No runtime behavior changed.

## Related

- SocioProphet/delivery-excellence#9
- SocioProphet/delivery-excellence-automation#7
- SocioProphet/sociosphere#273
- SocioProphet/agentplane#107
- SocioProphet/policy-fabric#60
- SocioProphet/memory-mesh#23