### PR TITLE
Replay RuntimeIdentityGraph contract follow-up clean

### DIFF
--- a/examples/runtime_identity_graph.json
+++ b/examples/runtime_identity_graph.json
@@ -1,0 +1,51 @@
+{
+  "id": "urn:srcos:runtime-identity-graph:bearbrowser_001",
+  "type": "RuntimeIdentityGraph",
+  "specVersion": "2.0.0",
+  "observedAt": "2026-05-06T22:37:03Z",
+  "rootComponentRef": "urn:srcos:component:BearBrowser",
+  "identityVerdict": "degraded",
+  "nodes": [
+    {
+      "nodeId": "app.bearbrowser",
+      "nodeKind": "app",
+      "displayName": "BearBrowser",
+      "processId": 54990,
+      "bundleOrPackageId": "application.dev.sourceos.BearBrowser",
+      "verificationVerdict": "valid"
+    },
+    {
+      "nodeId": "child.webcontent.54997",
+      "nodeKind": "browser-child",
+      "displayName": "WebContent",
+      "processId": 54997,
+      "bundleOrPackageId": "com.apple.WebKit.WebContent",
+      "verificationVerdict": "degraded"
+    },
+    {
+      "nodeId": "audit.webcontent.54997",
+      "nodeKind": "audit-token",
+      "displayName": "WebContent audit token",
+      "auditIdentity": "audit-token-unresolved",
+      "verificationVerdict": "ambiguous"
+    }
+  ],
+  "edges": [
+    {
+      "from": "app.bearbrowser",
+      "to": "child.webcontent.54997",
+      "relationship": "spawned"
+    },
+    {
+      "from": "child.webcontent.54997",
+      "to": "audit.webcontent.54997",
+      "relationship": "observed-as"
+    }
+  ],
+  "evidenceRefs": [
+    "urn:srcos:telemetry:te_invalid_product_id",
+    "urn:srcos:telemetry:te_audit_token_unresolved"
+  ],
+  "userVisibleImpact": "A browser child process launched, but its runtime identity could not be fully resolved.",
+  "remediationHint": "Verify child-process package identity, audit-token mapping, and broker registration before allowing page load."
+}

--- a/examples/runtime_identity_graph.json
+++ b/examples/runtime_identity_graph.json
@@ -1,51 +1,51 @@
 {
-  "id": "urn:srcos:runtime-identity-graph:bearbrowser_001",
+  "id": "urn:srcos:runtime-identity-graph:synthetic-browser-001",
   "type": "RuntimeIdentityGraph",
   "specVersion": "2.0.0",
   "observedAt": "2026-05-06T22:37:03Z",
-  "rootComponentRef": "urn:srcos:component:BearBrowser",
+  "rootComponentRef": "urn:srcos:component:synthetic-browser-surface",
   "identityVerdict": "degraded",
   "nodes": [
     {
-      "nodeId": "app.bearbrowser",
+      "nodeId": "app.synthetic-browser",
       "nodeKind": "app",
-      "displayName": "BearBrowser",
-      "processId": 54990,
-      "bundleOrPackageId": "application.dev.sourceos.BearBrowser",
+      "displayName": "Synthetic Browser Surface",
+      "processId": 1000,
+      "bundleOrPackageId": "application.example.synthetic-browser",
       "verificationVerdict": "valid"
     },
     {
-      "nodeId": "child.webcontent.54997",
+      "nodeId": "child.synthetic-content.1001",
       "nodeKind": "browser-child",
-      "displayName": "WebContent",
-      "processId": 54997,
-      "bundleOrPackageId": "com.apple.WebKit.WebContent",
+      "displayName": "Synthetic Content Surface",
+      "processId": 1001,
+      "bundleOrPackageId": "application.example.synthetic-content",
       "verificationVerdict": "degraded"
     },
     {
-      "nodeId": "audit.webcontent.54997",
+      "nodeId": "audit.synthetic-content.1001",
       "nodeKind": "audit-token",
-      "displayName": "WebContent audit token",
+      "displayName": "Synthetic content audit token",
       "auditIdentity": "audit-token-unresolved",
       "verificationVerdict": "ambiguous"
     }
   ],
   "edges": [
     {
-      "from": "app.bearbrowser",
-      "to": "child.webcontent.54997",
+      "from": "app.synthetic-browser",
+      "to": "child.synthetic-content.1001",
       "relationship": "spawned"
     },
     {
-      "from": "child.webcontent.54997",
-      "to": "audit.webcontent.54997",
+      "from": "child.synthetic-content.1001",
+      "to": "audit.synthetic-content.1001",
       "relationship": "observed-as"
     }
   ],
   "evidenceRefs": [
-    "urn:srcos:telemetry:te_invalid_product_id",
-    "urn:srcos:telemetry:te_audit_token_unresolved"
+    "urn:srcos:telemetry:synthetic-identity-degraded",
+    "urn:srcos:telemetry:synthetic-audit-token-unresolved"
   ],
-  "userVisibleImpact": "A browser child process launched, but its runtime identity could not be fully resolved.",
-  "remediationHint": "Verify child-process package identity, audit-token mapping, and broker registration before allowing page load."
+  "userVisibleImpact": "A synthetic child surface launched, but its runtime identity could not be fully resolved.",
+  "remediationHint": "Verify child-surface package identity, audit-token mapping, and broker registration before allowing page load."
 }

--- a/schemas/RuntimeIdentityGraph.json
+++ b/schemas/RuntimeIdentityGraph.json
@@ -1,0 +1,60 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.srcos.ai/v2/RuntimeIdentityGraph.json",
+  "title": "RuntimeIdentityGraph",
+  "description": "A runtime identity graph connecting process, package, executable, helper, broker, profile, session, and audit-token identity observations.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "id",
+    "type",
+    "specVersion",
+    "observedAt",
+    "rootComponentRef",
+    "identityVerdict",
+    "nodes"
+  ],
+  "properties": {
+    "id": { "type": "string", "pattern": "^urn:srcos:runtime-identity-graph:" },
+    "type": { "const": "RuntimeIdentityGraph" },
+    "specVersion": { "type": "string" },
+    "observedAt": { "type": "string", "format": "date-time" },
+    "rootComponentRef": { "type": "string", "minLength": 1 },
+    "identityVerdict": { "enum": ["valid", "degraded", "missing", "ambiguous", "invalid", "unknown"] },
+    "nodes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["nodeId", "nodeKind", "displayName"],
+        "properties": {
+          "nodeId": { "type": "string", "minLength": 1 },
+          "nodeKind": { "enum": ["app", "daemon", "xpc-service", "browser-child", "terminal-helper", "broker", "extension", "package", "profile", "session", "audit-token", "executable"] },
+          "displayName": { "type": "string", "minLength": 1 },
+          "processId": { "type": "integer", "minimum": 0 },
+          "bundleOrPackageId": { "type": "string" },
+          "executableDigest": { "type": "string" },
+          "auditIdentity": { "type": "string" },
+          "verificationVerdict": { "enum": ["valid", "degraded", "missing", "ambiguous", "invalid", "unknown"] }
+        }
+      }
+    },
+    "edges": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["from", "to", "relationship"],
+        "properties": {
+          "from": { "type": "string" },
+          "to": { "type": "string" },
+          "relationship": { "enum": ["spawned", "owns", "brokers", "uses-profile", "runs-as", "attests", "packages", "observed-as", "unknown"] }
+        }
+      }
+    },
+    "evidenceRefs": { "type": "array", "items": { "type": "string" } },
+    "userVisibleImpact": { "type": "string" },
+    "remediationHint": { "type": "string" }
+  }
+}

--- a/tools/validate_runtime_causality_examples.py
+++ b/tools/validate_runtime_causality_examples.py
@@ -13,15 +13,12 @@ PAIRS = [
     (ROOT / "schemas" / "SecurityVerdictState.json", ROOT / "examples" / "security_verdict_state.json"),
     (ROOT / "schemas" / "NetworkTruthState.json", ROOT / "examples" / "network_truth_state.json"),
     (ROOT / "schemas" / "BrowserLaunchTransaction.json", ROOT / "examples" / "browser_launch_transaction.json"),
+    (ROOT / "schemas" / "RuntimeIdentityGraph.json", ROOT / "examples" / "runtime_identity_graph.json"),
     (ROOT / "schemas" / "DesktopServiceBrokerState.json", ROOT / "examples" / "desktop_service_broker_state.json"),
     (ROOT / "schemas" / "MaintenanceEpoch.json", ROOT / "examples" / "maintenance_epoch.json"),
     (ROOT / "schemas" / "RuntimeRegistryIntegrityRecord.json", ROOT / "examples" / "runtime_registry_integrity_record.json"),
     (ROOT / "schemas" / "BootSessionPhaseState.json", ROOT / "examples" / "boot_session_phase_state.json"),
     (ROOT / "schemas" / "DiagnosticStormRecord.json", ROOT / "examples" / "diagnostic_storm_record.json"),
-]
-DEFERRED = [
-    "schemas/RuntimeIdentityGraph.json",
-    "examples/runtime_identity_graph.json",
 ]
 
 
@@ -37,7 +34,7 @@ def main() -> int:
     for schema_path, example_path in PAIRS:
         validate_pair(schema_path, example_path)
         checks[example_path.name] = True
-    print(json.dumps({"ok": all(checks.values()), "checks": checks, "deferred": DEFERRED}, indent=2, sort_keys=True))
+    print(json.dumps({"ok": all(checks.values()), "checks": checks}, indent=2, sort_keys=True))
     return 0
 
 


### PR DESCRIPTION
## Summary

Clean current-main replay of the deferred RuntimeIdentityGraph contract files from #100.

## Included

- `schemas/RuntimeIdentityGraph.json`
- `examples/runtime_identity_graph.json`

## Capture posture

This replaces noisy follow-up #109, whose branch carried the pre-squash #108 replay history. This PR should show only the deferred identity-graph files.