### PR TITLE
Replay execution control contracts on current main

### DIFF
--- a/.github/workflows/execution-control-contracts.yml
+++ b/.github/workflows/execution-control-contracts.yml
@@ -1,0 +1,56 @@
+name: Execution Control Contracts
+
+on:
+  pull_request:
+    branches: ["main"]
+    paths:
+      - "docs/execution-control-reconciliation-v0.3.md"
+      - "schemas/ExecutionFork.json"
+      - "schemas/RoutingContract.json"
+      - "schemas/ToolExposurePolicy.json"
+      - "schemas/QuotaPolicy.json"
+      - "schemas/RunnerGroup.json"
+      - "schemas/ProtocolWorkbench.json"
+      - "examples/execution_fork.json"
+      - "examples/routing_contract.json"
+      - "examples/tool_exposure_policy.json"
+      - "examples/quota_policy.json"
+      - "examples/runner_group.json"
+      - "examples/protocol_workbench.json"
+      - "tools/validate_execution_control_examples.py"
+      - ".github/workflows/execution-control-contracts.yml"
+  push:
+    branches: ["main", "replay/s104-current"]
+    paths:
+      - "docs/execution-control-reconciliation-v0.3.md"
+      - "schemas/ExecutionFork.json"
+      - "schemas/RoutingContract.json"
+      - "schemas/ToolExposurePolicy.json"
+      - "schemas/QuotaPolicy.json"
+      - "schemas/RunnerGroup.json"
+      - "schemas/ProtocolWorkbench.json"
+      - "examples/execution_fork.json"
+      - "examples/routing_contract.json"
+      - "examples/tool_exposure_policy.json"
+      - "examples/quota_policy.json"
+      - "examples/runner_group.json"
+      - "examples/protocol_workbench.json"
+      - "tools/validate_execution_control_examples.py"
+      - ".github/workflows/execution-control-contracts.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  validate-execution-control-contracts:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install validator dependencies
+        run: python -m pip install --upgrade pip jsonschema
+      - name: Validate execution control examples
+        run: python tools/validate_execution_control_examples.py

--- a/docs/execution-control-reconciliation-v0.3.md
+++ b/docs/execution-control-reconciliation-v0.3.md
@@ -1,0 +1,81 @@
+# Execution Control Reconciliation v0.3
+
+Status: planning baseline  
+Base: current `main` after agent harness, runtime observability, OpsHistory, reasoning, Agent Machine, local runtime, browser, and shell receipt tranches.
+
+## Purpose
+
+This note reconciles the proposed execution-control contract pack with the newer contract families already present in `sourceos-spec`.
+
+The goal is to avoid duplicate schema classes while preserving the missing control-plane vocabulary needed by downstream consumers.
+
+## Upstream families already present
+
+Recent upstream work already covers several adjacent domains:
+
+- Agent harness execution receipts: local runtime, shell, browser, host mutation, and download artifact receipt boundaries.
+- Runtime observability and capability governance: capability ledger, browser automation receipt, Git workspace state, orphan event receipt, and runtime install receipt.
+- OpsHistory: local-first operational history and redaction vocabulary.
+- Reasoning contracts: reasoning event, run, receipt, replay plan, and benchmark surfaces.
+- Agent Machine / model carry projections: model residency, inference provider, placement facts, and machine receipts.
+- Local runtime, browser history, shell receipt, and local-first service manifest surfaces.
+
+## Reuse-first decisions
+
+| Need | Reuse existing upstream surface | Net-new surface only if needed |
+|---|---|---|
+| Runtime receipt / execution proof | `AgentHarnessExecutionReceipts`, `RunRecord`, `SessionReceipt`, `TruthSurface`, `DeltaSurface` | No new generic run receipt in this tranche |
+| Browser, shell, terminal, host, and download evidence | Existing local-runtime, browser/shell, OpsHistory, and runtime observability receipts | No generic replacement evidence schema in this tranche |
+| Capability truth after reconciliation | `CapabilityLedger`, `Policy`, `PolicyDecision`, `CapabilityToken` | Optional `ToolExposurePolicy` for presentation-layer tool visibility only |
+| Workflow / validation program shape | `WorkflowSpec`, `WorkflowNode`, `WorkflowEdge`, `SkillManifest` | No new `ValidationProgram` schema in this tranche |
+| Agent skill packaging | `SkillManifest` | No new `AgentSkillBundle` schema in this tranche |
+| Lightweight environment fork | No exact current top-level schema | `ExecutionFork` remains net-new |
+| Request/session routing into a fork | No exact current top-level schema | `RoutingContract` remains net-new |
+| Team/developer runtime quota controls | No exact current top-level schema | `QuotaPolicy` remains net-new |
+| Runner image and primitive bundle | No exact current top-level schema | `RunnerGroup` remains net-new |
+| Protocol server test harness | No exact current top-level schema | `ProtocolWorkbench` remains net-new |
+| Generic artifact index | Partly covered by download/runtime receipts and Memory Mesh pointers | Defer `ArtifactDescriptor` until it aligns with existing artifact-pointer conventions |
+
+## Proposed v0.3 net-new tranche
+
+Add only these top-level schemas first:
+
+1. `ExecutionFork`
+2. `RoutingContract`
+3. `ToolExposurePolicy`
+4. `QuotaPolicy`
+5. `RunnerGroup`
+6. `ProtocolWorkbench`
+
+Defer or profile instead of adding:
+
+- `CapabilityPolicy`: use existing `Policy`, `PolicyDecision`, `CapabilityToken`, and `CapabilityLedger` until a genuine missing shape is proven.
+- `ArtifactDescriptor`: reconcile first with AgentHarness download artifact receipts, RuntimeInstall receipts, and Memory Mesh artifact pointer conventions.
+- `ValidationProgram`: profile `WorkflowSpec`.
+- `AgentSkillBundle`: profile `SkillManifest`.
+- `GovernedRun`: profile `RunRecord` and `AgentHarnessExecutionReceipts`.
+- `CairnEvidenceManifest`: profile `TruthSurface`, `DeltaSurface`, and existing provenance/receipt contracts.
+
+## Downstream alignment
+
+- `SocioProphet/agentplane`: consume `ExecutionFork`, `RoutingContract`, `RunnerGroup`, and `ProtocolWorkbench` as runtime orchestration inputs.
+- `SocioProphet/policy-fabric`: consume `ToolExposurePolicy` and `QuotaPolicy`; continue using existing policy decision/token flows for authority.
+- `SocioProphet/TriTRPC`: bind routing/workbench/session events to protocol frames.
+- `SourceOS-Linux/openclaw`: consume `ProtocolWorkbench` and `ToolExposurePolicy` for agent workbench and skill execution defaults.
+- `SourceOS-Linux/agent-term`, `TurtleTerm`, `sourceos-shell`, `BearBrowser`, and `agent-machine`: continue emitting the receipt families already added upstream.
+- `SociOS-Linux/workstation-contracts`: publish a workstation-safe subset profile.
+- `SocioProphet/socioprophet-agent-standards`: own conformance profiles, not canonical schemas.
+
+## Non-goals
+
+- No ADR in this tranche.
+- No replacement of current receipt or runtime-observability families.
+- No direct external-system wire compatibility promise.
+- No catalog count update until the exact schema tranche stabilizes.
+
+## Validation plan
+
+1. Add schemas and examples for the six net-new top-level objects.
+2. Add focused validators only after the shape stabilizes.
+3. Add OpenAPI/AsyncAPI patch entries later, when runtime producers are ready.
+4. Add derived profiles in downstream standards repos after canonical merge.

--- a/examples/execution_fork.json
+++ b/examples/execution_fork.json
@@ -1,0 +1,26 @@
+{
+  "id": "urn:srcos:execution-fork:checkout-example",
+  "type": "ExecutionFork",
+  "specVersion": "2.0.0",
+  "name": "checkout-example",
+  "substrate": "kubernetes",
+  "baselineRef": "urn:srcos:truth-surface:baseline-example",
+  "baselineDigest": "sha256:baseline-example",
+  "routingContractRef": "urn:srcos:routing-contract:checkout-example",
+  "runnerGroupRef": "urn:srcos:runner-group:validation-standard",
+  "quotaPolicyRef": "urn:srcos:quota:team-default",
+  "isolationRefs": ["urn:srcos:isolation:database-partition-example"],
+  "workloads": [
+    {
+      "name": "checkout",
+      "targetRef": "urn:srcos:workload:checkout",
+      "imageRef": "image.local/checkout:example",
+      "localPath": null,
+      "writePolicy": "isolated_only",
+      "envOverrides": { "FEATURE_MODE": "example" }
+    }
+  ],
+  "ttl": "8h",
+  "cleanupPolicy": "destroy_with_evidence_retained",
+  "tags": ["example", "validation"]
+}

--- a/examples/protocol_workbench.json
+++ b/examples/protocol_workbench.json
@@ -1,0 +1,24 @@
+{
+  "id": "urn:srcos:workbench:synthetic-mcp-validation",
+  "type": "ProtocolWorkbench",
+  "specVersion": "2.0.0",
+  "name": "Synthetic MCP validation workbench",
+  "protocol": "mcp",
+  "executionForkRef": "urn:srcos:execution-fork:synthetic-readonly-review",
+  "routingContractRef": "urn:srcos:routing-contract:synthetic-review-routing",
+  "serverUnderTest": {
+    "entrypoint": "synthetic-mcp-server",
+    "localMapping": true,
+    "previewUrlEnabled": false
+  },
+  "clientProfiles": ["synthetic-readonly-client"],
+  "trafficCapture": {
+    "captureRequests": true,
+    "captureResponses": true,
+    "captureToolCalls": true,
+    "redactSensitiveFields": true
+  },
+  "transcriptMode": "tool_call",
+  "validationRefs": ["urn:srcos:validation:synthetic-mcp-contract"],
+  "artifactClasses": ["transcript", "request_log", "response_log", "tool_trace"]
+}

--- a/examples/quota_policy.json
+++ b/examples/quota_policy.json
@@ -1,0 +1,27 @@
+{
+  "id": "urn:srcos:quota:synthetic-workbench-budget",
+  "type": "QuotaPolicy",
+  "specVersion": "2.0.0",
+  "name": "Synthetic workbench budget",
+  "version": "0.1.0",
+  "scope": "repo",
+  "selectors": {
+    "repository": "SourceOS-Linux/sourceos-spec",
+    "environmentClass": "synthetic"
+  },
+  "limits": {
+    "sandboxesCreatedPerWindow": 4,
+    "concurrentExecutionForks": 2,
+    "concurrentProtocolWorkbenches": 1,
+    "concurrentGovernedRuns": 2,
+    "testInvocationsPerWindow": 20,
+    "artifactStorageBytes": 104857600,
+    "logRetentionHours": 24
+  },
+  "window": {
+    "unit": "day",
+    "value": 1
+  },
+  "behaviorOnExceed": "queue",
+  "accountingMode": "admission_and_runtime"
+}

--- a/examples/routing_contract.json
+++ b/examples/routing_contract.json
@@ -1,0 +1,31 @@
+{
+  "id": "urn:srcos:routing-contract:checkout-example",
+  "type": "RoutingContract",
+  "specVersion": "2.0.0",
+  "name": "checkout-example",
+  "selectors": {
+    "headers": [
+      { "name": "x-routing-key", "op": "equals", "value": "checkout-example" }
+    ],
+    "actorRef": "urn:srcos:session:agent-example",
+    "branchRef": "checkout-example",
+    "missionRef": "urn:srcos:workflow:checkout-validation",
+    "trustClass": "low"
+  },
+  "targets": [
+    {
+      "name": "checkout-http",
+      "targetRef": "urn:srcos:workload:checkout",
+      "port": 8080,
+      "fallback": "baseline",
+      "writePolicy": "isolated_only"
+    }
+  ],
+  "propagation": {
+    "traceContext": "w3c",
+    "extraHeaders": ["x-routing-key", "x-agent-session"]
+  },
+  "defaultDeny": false,
+  "requireCapabilityToken": true,
+  "readOnlySurface": false
+}

--- a/examples/runner_group.json
+++ b/examples/runner_group.json
@@ -1,0 +1,16 @@
+{
+  "id": "urn:srcos:runner-group:synthetic-local-validation",
+  "type": "RunnerGroup",
+  "specVersion": "2.0.0",
+  "name": "Synthetic local validation runner group",
+  "version": "0.1.0",
+  "runtime": "local",
+  "imageRef": "synthetic-local-runner",
+  "imageDigestPinned": false,
+  "builtInPrimitives": ["jsonschema.validate", "artifact.hash", "report.emit"],
+  "customPrimitiveRefs": ["urn:srcos:primitive:synthetic-contract-check"],
+  "dependencyProfiles": ["python-jsonschema"],
+  "networkPolicyRef": null,
+  "filesystemPolicy": "ephemeral",
+  "cachePolicy": "none"
+}

--- a/examples/tool_exposure_policy.json
+++ b/examples/tool_exposure_policy.json
@@ -1,0 +1,16 @@
+{
+  "id": "urn:srcos:tool-exposure:synthetic-readonly-mcp",
+  "type": "ToolExposurePolicy",
+  "specVersion": "2.0.0",
+  "name": "Synthetic read-only MCP exposure",
+  "version": "0.1.0",
+  "transport": "mcp",
+  "exposureMode": "allow_list",
+  "policyRefs": ["urn:srcos:policy:synthetic-readonly-tools"],
+  "defaultToolsets": ["synthetic.repo.read"],
+  "includeTools": ["repo.status", "repo.diff", "artifact.read"],
+  "excludeTools": ["repo.write", "repo.push", "artifact.delete"],
+  "requireMutationConsent": true,
+  "sensitiveDataMode": "redacted",
+  "lockdownMode": true
+}

--- a/schemas/ExecutionFork.json
+++ b/schemas/ExecutionFork.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.srcos.ai/v2/ExecutionFork.json",
+  "title": "ExecutionFork",
+  "description": "A delta execution environment that overlays changed workloads, local mappings, and isolation references onto a shared baseline.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["id", "type", "specVersion", "name", "substrate", "baselineRef", "routingContractRef", "workloads", "cleanupPolicy"],
+  "properties": {
+    "id": { "type": "string", "pattern": "^urn:srcos:execution-fork:" },
+    "type": { "const": "ExecutionFork" },
+    "specVersion": { "type": "string" },
+    "name": { "type": "string" },
+    "description": { "type": "string" },
+    "substrate": { "type": "string", "enum": ["kubernetes", "local", "hybrid", "container", "vm"] },
+    "baselineRef": { "type": "string" },
+    "baselineDigest": { "type": "string" },
+    "routingContractRef": { "type": "string", "pattern": "^urn:srcos:routing-contract:" },
+    "runnerGroupRef": { "type": ["string", "null"], "pattern": "^urn:srcos:runner-group:" },
+    "quotaPolicyRef": { "type": ["string", "null"], "pattern": "^urn:srcos:quota:" },
+    "isolationRefs": { "type": "array", "items": { "type": "string" } },
+    "workloads": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["name", "targetRef"],
+        "properties": {
+          "name": { "type": "string" },
+          "targetRef": { "type": "string" },
+          "imageRef": { "type": ["string", "null"] },
+          "localPath": { "type": ["string", "null"] },
+          "writePolicy": { "type": "string", "enum": ["inherit", "isolated_only", "blocked"] },
+          "envOverrides": { "type": "object", "additionalProperties": { "type": "string" } }
+        }
+      }
+    },
+    "ttl": { "type": ["string", "null"] },
+    "cleanupPolicy": { "type": "string", "enum": ["destroy_with_evidence_retained", "destroy_all", "retain_for_debug"] },
+    "tags": { "type": "array", "items": { "type": "string" } }
+  }
+}

--- a/schemas/ProtocolWorkbench.json
+++ b/schemas/ProtocolWorkbench.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.srcos.ai/v2/ProtocolWorkbench.json",
+  "title": "ProtocolWorkbench",
+  "description": "A typed workbench for developing, testing, and validating protocol-facing servers such as MCP, TriTRPC, HTTP APIs, gRPC services, or A2A endpoints against an execution fork.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["id", "type", "specVersion", "name", "protocol", "executionForkRef", "serverUnderTest"],
+  "properties": {
+    "id": { "type": "string", "pattern": "^urn:srcos:workbench:" },
+    "type": { "const": "ProtocolWorkbench" },
+    "specVersion": { "type": "string" },
+    "name": { "type": "string" },
+    "protocol": { "type": "string", "enum": ["mcp", "a2a", "tritrpc", "http_api", "grpc"] },
+    "executionForkRef": { "type": "string", "pattern": "^urn:srcos:execution-fork:" },
+    "routingContractRef": { "type": ["string", "null"], "pattern": "^urn:srcos:routing-contract:" },
+    "serverUnderTest": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["entrypoint"],
+      "properties": {
+        "entrypoint": { "type": "string" },
+        "localMapping": { "type": "boolean" },
+        "previewUrlEnabled": { "type": "boolean" }
+      }
+    },
+    "clientProfiles": { "type": "array", "items": { "type": "string" } },
+    "trafficCapture": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "captureRequests": { "type": "boolean" },
+        "captureResponses": { "type": "boolean" },
+        "captureToolCalls": { "type": "boolean" },
+        "redactSensitiveFields": { "type": "boolean" }
+      }
+    },
+    "transcriptMode": { "type": "string", "enum": ["request_response", "tool_call", "mixed"] },
+    "validationRefs": { "type": "array", "items": { "type": "string" } },
+    "artifactClasses": {
+      "type": "array",
+      "items": { "type": "string", "enum": ["transcript", "screenshot", "request_log", "response_log", "schema_diff", "tool_trace", "preview_link"] }
+    }
+  }
+}

--- a/schemas/QuotaPolicy.json
+++ b/schemas/QuotaPolicy.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.srcos.ai/v2/QuotaPolicy.json",
+  "title": "QuotaPolicy",
+  "description": "A typed quota and resource allocation policy for execution forks, runs, protocol workbenches, and artifact retention windows.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["id", "type", "specVersion", "name", "version", "scope", "limits", "behaviorOnExceed"],
+  "properties": {
+    "id": { "type": "string", "pattern": "^urn:srcos:quota:" },
+    "type": { "const": "QuotaPolicy" },
+    "specVersion": { "type": "string" },
+    "name": { "type": "string" },
+    "version": { "type": "string" },
+    "scope": { "type": "string", "enum": ["organization", "team", "actor", "mission", "repo", "environment_class"] },
+    "selectors": { "type": "object", "additionalProperties": true },
+    "limits": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "sandboxesCreatedPerWindow": { "type": "integer", "minimum": 0 },
+        "concurrentExecutionForks": { "type": "integer", "minimum": 0 },
+        "concurrentProtocolWorkbenches": { "type": "integer", "minimum": 0 },
+        "concurrentGovernedRuns": { "type": "integer", "minimum": 0 },
+        "testInvocationsPerWindow": { "type": "integer", "minimum": 0 },
+        "artifactStorageBytes": { "type": "integer", "minimum": 0 },
+        "logRetentionHours": { "type": "integer", "minimum": 1 }
+      }
+    },
+    "window": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "unit": { "type": "string", "enum": ["hour", "day", "week", "month"] },
+        "value": { "type": "integer", "minimum": 1 }
+      }
+    },
+    "behaviorOnExceed": { "type": "string", "enum": ["reject", "queue", "degrade_read_only", "require_human_approval"] },
+    "accountingMode": { "type": "string", "enum": ["admission_only", "admission_and_runtime"] }
+  }
+}

--- a/schemas/RoutingContract.json
+++ b/schemas/RoutingContract.json
@@ -1,0 +1,65 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.srcos.ai/v2/RoutingContract.json",
+  "title": "RoutingContract",
+  "description": "A typed routing and propagation contract that selects requests, tool calls, or sessions and directs them toward an execution fork or baseline target.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["id", "type", "specVersion", "name", "targets"],
+  "properties": {
+    "id": { "type": "string", "pattern": "^urn:srcos:routing-contract:" },
+    "type": { "const": "RoutingContract" },
+    "specVersion": { "type": "string" },
+    "name": { "type": "string" },
+    "description": { "type": "string" },
+    "selectors": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "headers": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["name", "op", "value"],
+            "additionalProperties": false,
+            "properties": {
+              "name": { "type": "string" },
+              "op": { "type": "string", "enum": ["equals", "contains", "prefix"] },
+              "value": { "type": "string" }
+            }
+          }
+        },
+        "actorRef": { "type": ["string", "null"] },
+        "branchRef": { "type": ["string", "null"] },
+        "missionRef": { "type": ["string", "null"] },
+        "trustClass": { "type": ["string", "null"] }
+      }
+    },
+    "targets": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["name", "targetRef", "fallback", "writePolicy"],
+        "additionalProperties": false,
+        "properties": {
+          "name": { "type": "string" },
+          "targetRef": { "type": "string" },
+          "port": { "type": ["integer", "null"], "minimum": 1, "maximum": 65535 },
+          "fallback": { "type": "string", "enum": ["baseline", "deny"] },
+          "writePolicy": { "type": "string", "enum": ["inherit", "isolated_only", "blocked"] }
+        }
+      }
+    },
+    "propagation": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "traceContext": { "type": "string", "enum": ["w3c", "b3", "none"] },
+        "extraHeaders": { "type": "array", "items": { "type": "string" } }
+      }
+    },
+    "defaultDeny": { "type": "boolean" },
+    "requireCapabilityToken": { "type": "boolean" },
+    "readOnlySurface": { "type": "boolean" }
+  }
+}

--- a/schemas/RunnerGroup.json
+++ b/schemas/RunnerGroup.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.srcos.ai/v2/RunnerGroup.json",
+  "title": "RunnerGroup",
+  "description": "A versioned runtime bundle that supplies pinned images, built-in primitives, custom primitive extensions, and execution defaults for validations or protocol workbenches.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["id", "type", "specVersion", "name", "version", "runtime", "imageRef", "imageDigestPinned"],
+  "properties": {
+    "id": { "type": "string", "pattern": "^urn:srcos:runner-group:" },
+    "type": { "const": "RunnerGroup" },
+    "specVersion": { "type": "string" },
+    "name": { "type": "string" },
+    "version": { "type": "string" },
+    "runtime": { "type": "string", "enum": ["container", "wasm", "local", "hybrid"] },
+    "imageRef": { "type": "string" },
+    "imageDigestPinned": { "type": "boolean" },
+    "builtInPrimitives": { "type": "array", "items": { "type": "string" } },
+    "customPrimitiveRefs": { "type": "array", "items": { "type": "string" } },
+    "dependencyProfiles": { "type": "array", "items": { "type": "string" } },
+    "networkPolicyRef": { "type": ["string", "null"] },
+    "filesystemPolicy": { "type": "string", "enum": ["ephemeral", "retained", "read_only_base"] },
+    "cachePolicy": { "type": "string", "enum": ["none", "ephemeral", "shared_read_only"] }
+  }
+}

--- a/schemas/ToolExposurePolicy.json
+++ b/schemas/ToolExposurePolicy.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.srcos.ai/v2/ToolExposurePolicy.json",
+  "title": "ToolExposurePolicy",
+  "description": "A presentation-layer policy describing which tools or toolsets are exposed on an interaction surface. It can only reduce visibility relative to authority granted by existing policy and capability-token flows.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["id", "type", "specVersion", "name", "version", "transport", "exposureMode"],
+  "properties": {
+    "id": { "type": "string", "pattern": "^urn:srcos:tool-exposure:" },
+    "type": { "const": "ToolExposurePolicy" },
+    "specVersion": { "type": "string" },
+    "name": { "type": "string" },
+    "version": { "type": "string" },
+    "transport": { "type": "string", "enum": ["mcp", "tritrpc", "cli", "api"] },
+    "exposureMode": { "type": "string", "enum": ["full", "read_only", "allow_list", "deny_list", "consent_gated"] },
+    "policyRefs": { "type": "array", "items": { "type": "string" } },
+    "defaultToolsets": { "type": "array", "items": { "type": "string" } },
+    "includeTools": { "type": "array", "items": { "type": "string" } },
+    "excludeTools": { "type": "array", "items": { "type": "string" } },
+    "requireMutationConsent": { "type": "boolean" },
+    "sensitiveDataMode": { "type": "string", "enum": ["blocked", "redacted", "allowed"] },
+    "lockdownMode": { "type": "boolean" }
+  }
+}

--- a/tools/validate_execution_control_examples.py
+++ b/tools/validate_execution_control_examples.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+"""Validate execution-control schema/example pairs."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import jsonschema
+
+ROOT = Path(__file__).resolve().parents[1]
+PAIRS = [
+    (ROOT / "schemas" / "ExecutionFork.json", ROOT / "examples" / "execution_fork.json"),
+    (ROOT / "schemas" / "RoutingContract.json", ROOT / "examples" / "routing_contract.json"),
+    (ROOT / "schemas" / "ToolExposurePolicy.json", ROOT / "examples" / "tool_exposure_policy.json"),
+    (ROOT / "schemas" / "QuotaPolicy.json", ROOT / "examples" / "quota_policy.json"),
+    (ROOT / "schemas" / "RunnerGroup.json", ROOT / "examples" / "runner_group.json"),
+    (ROOT / "schemas" / "ProtocolWorkbench.json", ROOT / "examples" / "protocol_workbench.json"),
+]
+
+
+def validate_pair(schema_path: Path, example_path: Path) -> None:
+    schema = json.loads(schema_path.read_text(encoding="utf-8"))
+    jsonschema.validators.validator_for(schema).check_schema(schema)
+    example = json.loads(example_path.read_text(encoding="utf-8"))
+    jsonschema.validate(example, schema)
+
+
+def main() -> int:
+    checks: dict[str, bool] = {}
+    for schema_path, example_path in PAIRS:
+        validate_pair(schema_path, example_path)
+        checks[example_path.name] = True
+    print(json.dumps({"ok": all(checks.values()), "checks": checks}, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Replays the execution-control contract tranche from #104 onto current `main` with examples and focused validation.

## Included

- `docs/execution-control-reconciliation-v0.3.md`
- `schemas/ExecutionFork.json`
- `schemas/RoutingContract.json`
- `schemas/ToolExposurePolicy.json`
- `schemas/QuotaPolicy.json`
- `schemas/RunnerGroup.json`
- `schemas/ProtocolWorkbench.json`
- matching examples for all six schemas
- `tools/validate_execution_control_examples.py`
- focused `Execution Control Contracts` workflow

## Capture posture

Supersedes draft #104 after current-main checks pass.