### PR TITLE
Index SourceOS interaction substrate at top level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). Thi
 ## [Unreleased]
 
 ### Added
+- SourceOS interaction substrate top-level index and README discovery links for `SourceOSInteractionEvent`, generated TypeScript/Python artifacts, and the Noetica → Superconscious → AgentPlane → AgentTerm reference flow.
 - Runtime observability and capability governance contracts: `CapabilityLedger`, `BrowserAutomationReceipt`, `GitWorkspaceState`, `OrphanEventReceipt`, and `RuntimeInstallReceipt` with canonical examples, validation wiring (`tools/validate_runtime_observability_examples.py`), a contract catalog, and ADR-0012.
 - Reasoning run contracts: `ReasoningRun`, `ReasoningEvent`, `ReasoningReceipt`, `ReasoningReplayPlan`, and `ReasoningBenchmark` with canonical examples and a contract-additions note for the Superconscious reference loop.
 - Agent Machine / Model Carry schemas: `SourceOSModelCarryRef`, `InferenceProvider`, `ModelResidency`, `PlacementFact`, and `AgentMachineReceipt` with canonical examples and a contract-additions placement note.

--- a/README.md
+++ b/README.md
@@ -86,6 +86,28 @@ New machine-readable contracts:
 
 ---
 
+## SourceOS interaction substrate
+
+The SourceOS interaction substrate defines the governed noetic/chat/task event path shared by Noetica, AgentTerm, Superconscious, and AgentPlane.
+
+Start here:
+
+- [SourceOS Interaction Substrate Catalog](docs/contract-additions/sourceos-interaction-catalog.md)
+- [SourceOS Interaction Reference Flow](docs/contract-additions/sourceos-interaction-reference-flow.md)
+- [SourceOS Interaction Top-Level Index](docs/contract-additions/sourceos-interaction-top-level-index.md)
+- `schemas/SourceOSInteractionEvent.json`
+- `examples/interaction-flow/noetica-superconscious-agentplane-agentterm.flow.json`
+
+Validate locally:
+
+```bash
+python tools/validate_sourceos_interaction_examples.py
+python tools/generate_sourceos_interaction_types.py --check
+python tools/validate_interaction_flow_reference.py
+```
+
+---
+
 ## Schema families
 
 The schemas are organised into domain-oriented families that map to the SourceOS / SociOS contract surface:
@@ -103,6 +125,7 @@ The schemas are organised into domain-oriented families that map to the SourceOS
 | + | **Release / Experiments** | `ExperimentFlag`, `RolloutPolicy`, `ReleaseReceipt` |
 | + | **Fog Layer** | `Topic`, `TopicEnvelope`, `ReplicationPolicy`, `ContentRef`, `Offer`, `WorkOrder`, `UsageReceipt`, `SettlementEvent` |
 | + | **Agentic Graph Foundation** | `SourceOSRepoManifest`, `SyncEngineManifest`, `SourceChannelEnvelope`, `SourceGraphWrite`, `AgentCapabilityLease`, `AuditEvent` |
+| + | **Interaction Substrate** | `SourceOSInteractionEvent` |
 
 ---
 

--- a/docs/contract-additions/sourceos-interaction-top-level-index.md
+++ b/docs/contract-additions/sourceos-interaction-top-level-index.md
@@ -1,0 +1,38 @@
+# SourceOS Interaction Substrate Top-Level Index
+
+Status: informational index
+
+The SourceOS interaction substrate is the governed noetic/chat/task event path connecting browser chat, task-boundary coordination, execution evidence, and terminal rendering.
+
+Start here:
+
+- Canonical schema: `schemas/SourceOSInteractionEvent.json`
+- Base example: `examples/sourceos-interaction-event.json`
+- Generated TypeScript artifact: `generated/typescript/sourceos-interaction-event.ts`
+- Generated Python artifact: `generated/python/sourceos_interaction_event.py`
+- Substrate catalog: `docs/contract-additions/sourceos-interaction-catalog.md`
+- Reference flow: `docs/contract-additions/sourceos-interaction-reference-flow.md`
+- Reference manifest: `examples/interaction-flow/noetica-superconscious-agentplane-agentterm.flow.json`
+
+Implemented downstream roles:
+
+- `SocioProphet/Noetica`: browser chat and governance-trail emitter.
+- `SourceOS-Linux/agent-term`: terminal governance-trace renderer.
+- `SocioProphet/superconscious`: task-boundary reference binding.
+- `SocioProphet/agentplane`: evidence and replay reference binding.
+
+Validation commands:
+
+```bash
+python tools/validate_sourceos_interaction_examples.py
+python tools/generate_sourceos_interaction_types.py --check
+python tools/validate_interaction_flow_reference.py
+```
+
+Authority split:
+
+- `sourceos-spec` owns schema and generated contract artifacts.
+- Surfaces own rendering and user interaction.
+- Superconscious owns task-boundary coordination.
+- AgentPlane owns evidence and replay references.
+- Policy, identity/grants, and memory remain separate authority planes.


### PR DESCRIPTION
## Summary

Adds top-level discoverability for the SourceOS interaction substrate now that the canonical reference packet and downstream pointers are merged.

This PR adds:

- `docs/contract-additions/sourceos-interaction-top-level-index.md`
- README section for the SourceOS interaction substrate
- README schema-family entry for `SourceOSInteractionEvent`
- CHANGELOG entry under Unreleased

## Scope

Documentation/indexing only. No schema behavior changes.

## Validation expected

Existing docs/contract validation workflows should remain green.

## Related

- SourceOS-Linux/sourceos-spec#106
- SourceOS-Linux/sourceos-spec#115
- SourceOS-Linux/sourceos-spec#117
- SourceOS-Linux/sourceos-spec#118