### PR TITLE
Add SourceOS interaction implementation ledger

### DIFF
--- a/docs/contract-additions/sourceos-interaction-implementation-ledger.md
+++ b/docs/contract-additions/sourceos-interaction-implementation-ledger.md
@@ -1,0 +1,86 @@
+# SourceOS Interaction Substrate Implementation Ledger
+
+Status: implementation ledger  
+Last updated: 2026-05-31
+
+## Purpose
+
+This ledger records the completed SourceOS interaction substrate implementation wave across the canonical contract repo and downstream consumer repos.
+
+The substrate connects:
+
+```text
+Noetica
+  -> SourceOSInteractionEvent
+  -> Superconscious task-boundary refs
+  -> AgentPlane evidence/replay refs
+  -> AgentTerm governance-trace rendering
+```
+
+It is not a new authority plane. It is a shared contract path across existing planes.
+
+## Canonical contract estate
+
+| Repository | PR | Merge commit | Role |
+| --- | --- | --- | --- |
+| `SourceOS-Linux/sourceos-spec` | `#106` | contract schema tranche | Added `SourceOSInteractionEvent`, example, validator, and schema workflow. |
+| `SourceOS-Linux/sourceos-spec` | `#115` | catalog tranche | Indexed the interaction substrate in schema/example/contract catalogs. |
+| `SourceOS-Linux/sourceos-spec` | `#117` | `c7f8c2d9e42a56e1127c2f9b85649cbea0f0a9fa` | Added generated TypeScript/Python artifacts and codegen drift check. |
+| `SourceOS-Linux/sourceos-spec` | `#118` | `373c49581634b81dbfd3c7ae7b4a6522cadd1b6d` | Added canonical end-to-end reference-flow packet. |
+| `SourceOS-Linux/sourceos-spec` | `#119` | `6ca2909011279ad7312c4e1e39b64eea42c2105b` | Added top-level README/changelog/index discoverability. |
+
+## Downstream implementation estate
+
+| Repository | PR / commit | Merge commit | Role |
+| --- | --- | --- | --- |
+| `SocioProphet/Noetica` | `#16` | emitter tranche | Emits `SourceOSInteractionEvent` from chat lifecycle. |
+| `SocioProphet/Noetica` | `#17` | `6d84be0b4c92b06f00cfce60bb9cae1cea1b4747` | Vendors generated TypeScript contract artifact. |
+| `SocioProphet/Noetica` | `#18` | `2a73b44338335a39283bcf65b4e072e29b8946a3` | Adds SourceOS contract-sync check. |
+| `SocioProphet/Noetica` | `#19` | `defba9a536706f3f5af8decd2ac4f1d8f594b2a4` | Adds downstream reference-flow pointer. |
+| `SourceOS-Linux/agent-term` | `#46` | `888c83e933d5edca816cfb071af78dba8722a9a6` | Renders and records interaction governance traces. |
+| `SourceOS-Linux/agent-term` | `#47` | `0a7b431f48239bb3f1413abfe2a07da60cb1cdd9` | Vendors generated Python contract artifact. |
+| `SourceOS-Linux/agent-term` | `#48` | `076db5f0ebd6acae665a0b3b90e56c88735bc301` | Adds SourceOS contract-sync check. |
+| `SourceOS-Linux/agent-term` | `#49` | `f4272d86e38d999e70f3b3b774bcf8c53695d1f6` | Adds downstream reference-flow pointer. |
+| `SocioProphet/superconscious` | `#60` | `a4742b092584432871a7a15da49e15f054b8d393` | Adds task-boundary binding, schema, fixtures, and checker. |
+| `SocioProphet/superconscious` | direct doc pointer | `5cf46a4ca5a8a1f7c399d72305ec29a891f267fe` | Adds downstream reference-flow pointer. |
+| `SocioProphet/agentplane` | `#253` | `e9797a8358405475fc12eb94d5c6b00547bd0ddf` | Adds evidence/replay binding, schema, fixtures, validator, and workflow. |
+| `SocioProphet/agentplane` | `#254` | `6e932f54f6391ed3c0ef971054bb67307ea28da9` | Adds downstream reference-flow pointer. |
+
+## Validation lanes
+
+| Repository | Validation lane |
+| --- | --- |
+| `sourceos-spec` | `SourceOS Interaction Substrate`, `SourceOS Interaction Codegen`, `SourceOS Interaction Reference Flow`, `SVF Validation`, `validate-ops-history` |
+| `Noetica` | `validate`, `SourceOS Contract Sync` |
+| `agent-term` | `CI`, `SourceOS Contract Sync` |
+| `superconscious` | `Superconscious CI`, `SVF Validation`, `Trust Surface`, `lawful-learning-t2-prime` for the clean boundary PR head; Certificate Doctrine remained separately red on an unrelated lane during that merge. |
+| `agentplane` | `lint`, `validate`, `tests`, `ci`, `SourceOS Interaction Evidence Binding` |
+
+## Authority boundaries
+
+| Plane | Authority |
+| --- | --- |
+| `sourceos-spec` | Canonical schema, examples, generated artifacts, and reference-flow packet. |
+| `Noetica` | Browser chat and inline governance trace surface. |
+| `AgentTerm` | Terminal/operator governance-trace rendering and local event-recording surface. |
+| `Superconscious` | Task/cognition boundary references. |
+| `AgentPlane` | Execution evidence, validation, placement, run, and replay references. |
+| Policy Fabric | Policy admission. |
+| Agent Registry | Identity, grants, sessions, and revocation. |
+| Memory Mesh | Durable memory and context-pack semantics. |
+
+## Non-goals of the completed tranche
+
+- No live cross-service runtime bridge was added.
+- No policy authority moved into Noetica, AgentTerm, Superconscious, or AgentPlane.
+- No memory authority moved into any surface.
+- No raw transcript, secret, credential, raw execution log, or private reasoning payload is authorized.
+- No package/submodule replacement for pinned vendoring was implemented; pinned sync checks now guard drift.
+
+## Remaining non-blocking future work
+
+1. Replace vendored generated artifacts with a small `sourceos-contracts` package or a managed subtree/submodule strategy.
+2. Add a live event-export path from Noetica to AgentTerm once the transport decision is ready.
+3. Bind Policy Fabric, Agent Registry, and Memory Mesh with the same reference-flow discipline.
+4. Add a replay demo that consumes the canonical reference-flow packet without live service dependencies.
+5. Add Sociosphere workspace-level tracking for the interaction substrate when the workspace lock format is ready.


### PR DESCRIPTION
## Summary

Adds a compact implementation ledger for the completed SourceOS interaction substrate wave.

This PR adds:

- `docs/contract-additions/sourceos-interaction-implementation-ledger.md`

The ledger records:

- canonical `sourceos-spec` PRs and commits;
- downstream implementation PRs and commits;
- validation lanes used;
- authority boundaries;
- non-goals;
- remaining non-blocking future work.

## Scope

Documentation only. No schema behavior changes.

## Related

- SourceOS-Linux/sourceos-spec#106
- SourceOS-Linux/sourceos-spec#115
- SourceOS-Linux/sourceos-spec#117
- SourceOS-Linux/sourceos-spec#118
- SourceOS-Linux/sourceos-spec#119
- SocioProphet/Noetica#16
- SocioProphet/Noetica#17
- SocioProphet/Noetica#18
- SocioProphet/Noetica#19
- SourceOS-Linux/agent-term#46
- SourceOS-Linux/agent-term#47
- SourceOS-Linux/agent-term#48
- SourceOS-Linux/agent-term#49
- SocioProphet/superconscious#60
- SocioProphet/agentplane#253
- SocioProphet/agentplane#254