### PR TITLE
contracts: replay workstation Mac-on-Linux polish signals

### DIFF
--- a/docs/workstation-contract-family.md
+++ b/docs/workstation-contract-family.md
@@ -41,6 +41,36 @@ Specifically:
 - `DesktopProfile` describes the desktop posture, not a policy canon.
 - `WorkstationProfile` ties these together for a workstation lane while referencing—not redefining—execution/audit semantics elsewhere.
 
+## Mac-on-Linux polish signals
+
+`SociOS-Linux/source-os` has added workstation-v0 Mac-on-Linux polish surfaces. The canonical
+contract examples reflect these signals without over-claiming implementation parity.
+
+**Implementation authority** for all polish features below remains in `SociOS-Linux/source-os`.
+This repository owns only the typed contract descriptors and examples.
+
+### Currently active signals (reflected in examples)
+
+| Signal | Contract field | Example value |
+|--------|---------------|---------------|
+| Screenshot helper | `WorkstationProfile.macOnLinuxPolish.screenshotHelperCommand` | `"sourceos-screenshot"` |
+| Quick Look / Sushi file preview | `WorkstationProfile.macOnLinuxPolish.quickLookPackages` | `["sushi", "gnome-sushi"]` |
+| Mac keyboard remap policy | `WorkstationProfile.macOnLinuxPolish.keymapPolicyRef` | `urn:srcos:keymap-profile:mac-linux-primary` |
+| Aggregate polish validation | `WorkstationProfile.validation.polishValidationCommand` | `"sourceos polish validate --json"` |
+| Bounded appearance defaults | `DesktopProfile.appearance` | `colorScheme: dark, fontScaling: 1.0` |
+| Sidebar bookmarks (Finder-style) | `DesktopProfile.sidebarBookmarks` | Home, Desktop, Documents, Downloads, Code |
+
+### Future / non-goal signals (not yet in examples)
+
+The following signals are tracked as follow-on work and are **not** represented in the current
+examples. They should not be claimed as implemented until the corresponding feature lands in
+`SociOS-Linux/source-os` and is verified:
+
+- Deep Sushi/QuickLook MIME-type extension registration
+- Per-app appearance override surfaces
+- Native assistant bridge for Siri/Shortcuts-style flows (see `native_assistant_bridge_profile.apple_app_intents.json`)
+- Full macOS parity — this is explicitly a **non-goal**; SourceOS targets polish, not emulation.
+
 ## Immediate alignment target
 
 This family is intended to align with the current Linux realization in `SociOS-Linux/source-os`, including:
@@ -48,9 +78,11 @@ This family is intended to align with the current Linux realization in `SociOS-L
 - GNOME desktop defaults and extension pinset
 - SourceOS palette / command-bus posture
 - Lampstand-backed local file search
+- Mac-on-Linux polish surfaces (screenshot, Quick Look/Sushi, sidebar bookmarks, appearance defaults, keyboard remap)
 
 ## Follow-on contract work
 
 1. Add richer search-provider and validation sub-objects once the shell/runtime product repo stabilizes.
 2. Add typed references for doctor/fix report families and runtime execution surfaces.
 3. Bind these objects into OpenAPI / AsyncAPI surfaces when the first product/runtime consumers are ready.
+4. Add negative examples for future/non-goal polish signals once the boundary is further stabilized.

--- a/examples/desktopprofile.json
+++ b/examples/desktopprofile.json
@@ -78,5 +78,17 @@
       "libadwaita-replacement",
       "proprietary-asset-requirement"
     ]
-  }
+  },
+  "appearance": {
+    "colorScheme": "dark",
+    "accentColor": null,
+    "fontScaling": 1.0
+  },
+  "sidebarBookmarks": [
+    { "label": "Home", "path": "~/" },
+    { "label": "Desktop", "path": "~/Desktop" },
+    { "label": "Documents", "path": "~/Documents" },
+    { "label": "Downloads", "path": "~/Downloads" },
+    { "label": "Code", "path": "~/code" }
+  ]
 }

--- a/examples/workstationprofile.json
+++ b/examples/workstationprofile.json
@@ -13,6 +13,13 @@
   "validation": {
     "doctorCommand": "sourceos doctor --json",
     "statusCommand": "sourceos status --json",
-    "searchCommand": "sourceos search --snippet"
+    "searchCommand": "sourceos search --snippet",
+    "polishValidationCommand": "sourceos polish validate --json"
+  },
+  "macOnLinuxPolish": {
+    "status": "active",
+    "screenshotHelperCommand": "sourceos-screenshot",
+    "quickLookPackages": ["gnome-sushi"],
+    "keymapPolicyRef": "urn:srcos:keymap-profile:mac-linux-primary"
   }
 }

--- a/schemas/DesktopProfile.json
+++ b/schemas/DesktopProfile.json
@@ -96,6 +96,39 @@
           "description": "Explicit non-goals for this desktop profile."
         }
       }
+    },
+    "appearance": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Bounded appearance defaults for the desktop environment.",
+      "properties": {
+        "colorScheme": {
+          "type": "string",
+          "enum": ["light", "dark", "follow-system"],
+          "description": "Preferred color scheme."
+        },
+        "accentColor": {
+          "type": ["string", "null"],
+          "description": "Accent color token or hex value."
+        },
+        "fontScaling": {
+          "type": ["number", "null"],
+          "description": "Font scaling factor (1.0 = default)."
+        }
+      }
+    },
+    "sidebarBookmarks": {
+      "type": "array",
+      "description": "Sidebar (e.g., Files/Nautilus) bookmark entries mirroring Mac Finder sidebar conventions.",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["label", "path"],
+        "properties": {
+          "label": { "type": "string", "minLength": 1 },
+          "path": { "type": "string", "minLength": 1 }
+        }
+      }
     }
   }
 }

--- a/schemas/WorkstationProfile.json
+++ b/schemas/WorkstationProfile.json
@@ -59,9 +59,38 @@
       "properties": {
         "doctorCommand": { "type": ["string", "null"] },
         "statusCommand": { "type": ["string", "null"] },
-        "searchCommand": { "type": ["string", "null"] }
+        "searchCommand": { "type": ["string", "null"] },
+        "polishValidationCommand": {
+          "type": ["string", "null"],
+          "description": "Aggregate Mac-on-Linux polish validation entrypoint."
+        }
       },
       "description": "Operator-facing validation and inspection entrypoints."
+    },
+    "macOnLinuxPolish": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Mac-on-Linux polish signal set. Implementation authority: SociOS-Linux/source-os. Use 'status: active' for signals that are live in SociOS-Linux/source-os; use 'planned' or 'non-goal' to record intent or explicit exclusions.",
+      "properties": {
+        "status": {
+          "type": "string",
+          "enum": ["active", "planned", "non-goal"],
+          "description": "Implementation state of the Mac-on-Linux polish surface for this profile. Use 'active' for features shipped in SociOS-Linux/source-os, 'planned' for accepted follow-on work, and 'non-goal' to explicitly record excluded features."
+        },
+        "screenshotHelperCommand": {
+          "type": ["string", "null"],
+          "description": "Shell command providing Mac-style screenshot capture (e.g. sourceos-screenshot)."
+        },
+        "quickLookPackages": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 },
+          "description": "Package names providing Quick Look / Sushi-compatible file preview support."
+        },
+        "keymapPolicyRef": {
+          "type": ["string", "null"],
+          "description": "URN reference to a KeymapProfile expressing the Mac-keyboard remap policy."
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary

Fresh current-base replay of #81.

This preserves the workstation Mac-on-Linux polish contract surfaces from the stale/non-mergeable Copilot PR while respecting current `main`, which already had a broader `DesktopProfile.macOnLinuxPolish` metadata object.

## Captured from #81

- `WorkstationProfile.validation.polishValidationCommand`
- `WorkstationProfile.macOnLinuxPolish`
- `DesktopProfile.appearance`
- `DesktopProfile.sidebarBookmarks`
- workstation and desktop example updates
- `docs/workstation-contract-family.md` Mac-on-Linux polish boundary documentation

## Current-main preservation

The replay preserves current `DesktopProfile.macOnLinuxPolish` fields already present on main:

- `implementationAuthority`
- `activeFeatures`
- `validationBackedFeatures`
- `proposedFeatures`
- `nonGoals`

## Boundary

- Additive schema/example/docs contract replay only.
- Implementation authority remains `SociOS-Linux/source-os`.
- No full macOS parity claim.
- No runtime implementation.
- No package-manager changes.
- No UI asset or proprietary asset dependency.

## Supersedes

Supersedes stale/non-mergeable #81 after this replacement lands.