### PR TITLE
Index Noetica interaction placement addendum

### DIFF
--- a/docs/contract-additions/sourceos-interaction-top-level-index.md
+++ b/docs/contract-additions/sourceos-interaction-top-level-index.md
@@ -12,11 +12,12 @@ Start here:
 - Generated Python artifact: `generated/python/sourceos_interaction_event.py`
 - Substrate catalog: `docs/contract-additions/sourceos-interaction-catalog.md`
 - Reference flow: `docs/contract-additions/sourceos-interaction-reference-flow.md`
+- Noetica placement addendum: `docs/contract-additions/sourceos-interaction-noetica-placement-addendum.md`
 - Reference manifest: `examples/interaction-flow/noetica-superconscious-agentplane-agentterm.flow.json`
 
 Implemented downstream roles:
 
-- `SocioProphet/Noetica`: browser chat and governance-trail emitter.
+- `SocioProphet/Noetica`: browser chat / desktop surface and governance-trail emitter, with future runtime emission placed at the typed transport / local-service boundary.
 - `SourceOS-Linux/agent-term`: terminal governance-trace renderer.
 - `SocioProphet/superconscious`: task-boundary reference binding.
 - `SocioProphet/agentplane`: evidence and replay reference binding.
@@ -33,6 +34,7 @@ Authority split:
 
 - `sourceos-spec` owns schema and generated contract artifacts.
 - Surfaces own rendering and user interaction.
+- Noetica transport/local-service boundary is the preferred future emission placement for live Noetica events.
 - Superconscious owns task-boundary coordination.
 - AgentPlane owns evidence and replay references.
 - Policy, identity/grants, and memory remain separate authority planes.


### PR DESCRIPTION
## Summary

Indexes the Noetica interaction placement addendum from the SourceOS interaction top-level index.

This follows the merged Noetica placement work in `SocioProphet/Noetica#45` and records that future Noetica runtime event emission should attach at the typed transport / local-service boundary.

## Scope

Documentation/indexing only. No schema behavior changes.

## Related

- SocioProphet/Noetica#45
- SourceOS-Linux/sourceos-spec#118
- SourceOS-Linux/sourceos-spec#120