### PR TITLE
Add SourceOS interaction runtime bridge ledger

### DIFF
--- a/docs/contract-additions/sourceos-interaction-runtime-bridge-ledger.md
+++ b/docs/contract-additions/sourceos-interaction-runtime-bridge-ledger.md
@@ -1,0 +1,71 @@
+# SourceOS Interaction Runtime Bridge Ledger
+
+Status: implementation ledger  
+Last updated: 2026-06-01
+
+## Purpose
+
+This ledger records the bounded runtime bridge work added after the original SourceOS interaction substrate contract/reference wave.
+
+The bridge remains pull/import oriented:
+
+```text
+Noetica typed transport / local-service boundary
+  -> bounded SourceOSInteractionEvent JSON artifact export
+  -> optional AgentTerm import/render
+```
+
+It does not introduce live service coupling, event streaming, OpsHistory authority, AgentTerm default dependency, or production runtime authority.
+
+## Completed bridge tranches
+
+| Repository | PR | Merge commit | Role |
+| --- | --- | --- | --- |
+| `SocioProphet/Noetica` | `#45` | `986059dbe7fc5bf8435c784ad5adbf4230dfca78` | Added transport/local-service placement guidance and fixture-only SourceOS interaction examples. |
+| `SourceOS-Linux/sourceos-spec` | direct + `#122` | `87d66e8160b55d9fabaacb4140bac339dc6de312`, `c23db7c7736e114cb753c26f867cef7590666e1a` | Added and indexed the Noetica placement addendum. |
+| `SocioProphet/Noetica` | `#47` | `60b720f5c43f4fe2b315a9e81078b3c48b1e5160` | Added ADR-0001 selecting bounded local artifact/export as the first runtime bridge target. |
+| `SocioProphet/Noetica` | `#48` | `b09a7bbf4a843dd9cd7b54a80537d7dc8b551302` | Added SourceOS interaction event builders, deterministic fixture-backed artifact export, package script, and CI validation. |
+| `SourceOS-Linux/agent-term` | `#50` | `61870a9dff19c93cceeb0c521d008e041214140a` | Added opt-in Noetica artifact import from file/directory into AgentTerm's local event log. |
+
+## Current implementation shape
+
+Noetica owns bounded artifact export from its transport/local-service boundary:
+
+- `lib/sourceos/interactionEvent.ts`
+- `scripts/export-sourceos-interaction-events.mjs`
+- `npm run sourceos:events:export`
+- CI validation through `validate.yml`
+
+AgentTerm owns opt-in artifact import/render:
+
+- `src/agent_term/noetica_import.py`
+- `agent-term-interaction import-noetica <file-or-directory>`
+- import tests for single-file and directory imports
+
+## Validation lanes
+
+| Repository | Validation |
+| --- | --- |
+| `SocioProphet/Noetica` | `validate` passed for `#45`, `#47`, and `#48`. |
+| `SourceOS-Linux/agent-term` | `CI` passed for `#50`. |
+| `SourceOS-Linux/sourceos-spec` | `SVF Validation` and `validate-ops-history` passed for `#122`. |
+
+## Boundary posture
+
+The bridge is intentionally bounded:
+
+- No live Noetica-to-AgentTerm stream was added.
+- No AgentTerm dependency was added to Noetica's default runtime path.
+- No local endpoint serving was added.
+- No SSE/WebSocket path was added.
+- No OpsHistory append-only authority was added.
+- No Policy Fabric, Agent Registry, Memory Mesh, Superconscious, or AgentPlane authority moved into Noetica or AgentTerm.
+- Events remain summary/ref-oriented and must not carry private reasoning, raw transcripts, raw shell output, browser history, credentials, secrets, unrestricted provider payloads, or raw execution logs.
+
+## Remaining work
+
+1. Add production app-data export path selection once Noetica's local service install/runtime contract stabilizes.
+2. Add an AgentTerm import smoke command or fixture path example to operator docs.
+3. Decide whether Noetica should expose recent events through a local endpoint after artifact export is stable.
+4. Decide whether OpsHistory becomes the durable event store after artifact export/import is proven.
+5. Bind Policy Fabric, Agent Registry, and Memory Mesh references into real runtime emissions when their boundaries are ready.


### PR DESCRIPTION
## Summary

Adds a runtime bridge ledger for the bounded Noetica artifact export and AgentTerm opt-in import work.

This PR adds:

- `docs/contract-additions/sourceos-interaction-runtime-bridge-ledger.md`

## Scope

Documentation only. No schema behavior changes.

The ledger records:

- Noetica transport/local-service placement guidance
- Noetica bounded artifact export bridge
- AgentTerm opt-in artifact import path
- validation lanes
- remaining work and non-goals

## Related

- SocioProphet/Noetica#45
- SocioProphet/Noetica#47
- SocioProphet/Noetica#48
- SourceOS-Linux/agent-term#50
- SourceOS-Linux/sourceos-spec#122