### PR TITLE
feat(SyncCycleReceipt): add optional agentplaneRunRef field

### DIFF
--- a/schemas/SyncCycleReceipt.json
+++ b/schemas/SyncCycleReceipt.json
@@ -118,6 +118,10 @@
       "type": "string",
       "pattern": "^urn:srcos:audit:",
       "description": "AuditEvent id that records this sync cycle in the append-only audit log."
+    },
+    "agentplaneRunRef": {
+      "type": ["string", "null"],
+      "description": "Optional URN or path reference to the agentplane RunArtifact that triggered the build producing this sync cycle. Links the governance execution trace to the SourceOS sync event."
     }
   }
 }


### PR DESCRIPTION
- Adds optional \`agentplaneRunRef\` field (\`string | null\`) to \`SyncCycleReceipt\`
- Links a sync receipt to the agentplane \`RunArtifact\` that triggered the build, closing the audit trail gap between governance execution and the SourceOS sync event
- Not in \`required\`; all existing receipts remain valid