### PR TITLE
Add DeviceIdentity example, validation + registration endpoint

### DIFF
--- a/examples/device_identity.json
+++ b/examples/device_identity.json
@@ -1,0 +1,16 @@
+{
+  "id": "urn:srcos:device-identity:rack-01",
+  "type": "DeviceIdentity",
+  "specVersion": "2.0.0",
+  "deviceName": "rack-01",
+  "platform": "linux",
+  "archClass": "x86_64",
+  "trustProfile": {
+    "trustLevel": "provisional",
+    "enrolledAt": "2026-06-22T00:00:00Z"
+  },
+  "ownerRef": "urn:srcos:user:operator-9",
+  "registeredAt": "2026-06-22T00:00:00Z",
+  "policyDecisionRefs": [],
+  "evidenceRefs": []
+}

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -608,6 +608,33 @@ paths:
           description: Request body is valid JSON but fails schema validation.
           content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } }
 
+  /v2/device-identities:
+    post:
+      operationId: upsertDeviceIdentity
+      summary: Upsert a DeviceIdentity
+      description: Registers or updates a fleet device identity (name, platform, trust profile, owner) that NLBoot plans target and boot proofs reference. Idempotent on `id`.
+      tags: [Boot]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: './schemas/DeviceIdentity.json' }
+      responses:
+        '200':
+          description: DeviceIdentity registered or updated successfully.
+        '400':
+          description: Request body is malformed JSON.
+          content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } }
+        '401':
+          description: Missing or invalid authentication token.
+          content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } }
+        '403':
+          description: Authenticated subject is not permitted to register device identities.
+          content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } }
+        '422':
+          description: Request body is valid JSON but fails schema validation.
+          content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } }
+
   /v2/apple-silicon-adapter-evidence:
     post:
       operationId: recordAppleSiliconAdapterEvidence

--- a/tools/validate_nlboot_examples.py
+++ b/tools/validate_nlboot_examples.py
@@ -12,6 +12,7 @@ PAIRS = [
     (ROOT / "schemas" / "NLBootPlan.json", ROOT / "examples" / "nlboot_plan.json"),
     (ROOT / "schemas" / "ArtifactCacheRecord.json", ROOT / "examples" / "artifact_cache_record.json"),
     (ROOT / "schemas" / "BootProofRecord.json", ROOT / "examples" / "boot_proof_record.json"),
+    (ROOT / "schemas" / "DeviceIdentity.json", ROOT / "examples" / "device_identity.json"),
     (ROOT / "schemas" / "AppleSiliconAdapterEvidence.json", ROOT / "examples" / "apple_silicon_adapter_evidence.json"),
     # Release and build lifecycle objects
     (ROOT / "schemas" / "ReleaseSet.json", ROOT / "examples" / "release_set.json"),


### PR DESCRIPTION
`DeviceIdentity` had a schema but was the only boot/fleet object with **no example, no validator coverage, and no API operation** — the missing peer to `NLBootPlan` and `BootProofRecord`.

## Changes
- **`examples/device_identity.json`** — a registered fleet device (provisional trust, owner, x86_64), validated against `schemas/DeviceIdentity.json`.
- **`tools/validate_nlboot_examples.py`** — add the `DeviceIdentity` schema/example pair so `make validate` covers it.
- **`openapi.yaml`** — `POST /v2/device-identities` (`upsertDeviceIdentity`), mirroring `/v2/nlboot-plans` and `/v2/boot-proof-records` (tags `[Boot]`, idempotent on `id`).

## Why
Surfaced while conforming the SourceOS image-builder/fleet to these contracts (socioprophet#395): a device registers (`DeviceIdentity`) → gets an `NLBootPlan` → reports a `BootProofRecord`. The first step had no canonical example or endpoint; this closes the loop in the canonical repo.

`make validate` → `OK: validate`.