### PR TITLE
feat(contracts): cockpit contract pack — agentic-os / triparty / labor / supply-risk

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,23 @@
-.PHONY: validate validate-control-plane-examples validate-nlboot-examples validate-lattice-data-governai-examples validate-ops-history-examples validate-runtime-observability-examples validate-interpretability-examples validate-lifecycle-boundary-examples validate-svf-contracts validate-sync-cycle-receipts validate-onboarding-examples validate-runtime-causality-examples
+.PHONY: validate validate-control-plane-examples validate-nlboot-examples validate-lattice-data-governai-examples validate-ops-history-examples validate-runtime-observability-examples validate-interpretability-examples validate-lifecycle-boundary-examples validate-svf-contracts validate-sync-cycle-receipts validate-onboarding-examples validate-runtime-causality-examples validate-agentic-os-examples validate-triparty-examples validate-labor-market-examples validate-supply-chain-risk-examples
 
-validate: validate-control-plane-examples validate-nlboot-examples validate-lattice-data-governai-examples validate-ops-history-examples validate-runtime-observability-examples validate-interpretability-examples validate-lifecycle-boundary-examples validate-svf-contracts validate-sync-cycle-receipts validate-onboarding-examples validate-runtime-causality-examples
+validate: validate-control-plane-examples validate-nlboot-examples validate-lattice-data-governai-examples validate-ops-history-examples validate-runtime-observability-examples validate-interpretability-examples validate-lifecycle-boundary-examples validate-svf-contracts validate-sync-cycle-receipts validate-onboarding-examples validate-runtime-causality-examples validate-agentic-os-examples validate-triparty-examples validate-labor-market-examples validate-supply-chain-risk-examples
 	@echo "OK: validate"
+
+validate-agentic-os-examples:
+	python3 -m pip install --user jsonschema >/dev/null
+	python3 tools/validate_agentic_os_examples.py
+
+validate-triparty-examples:
+	python3 -m pip install --user jsonschema >/dev/null
+	python3 tools/validate_triparty_examples.py
+
+validate-labor-market-examples:
+	python3 -m pip install --user jsonschema >/dev/null
+	python3 tools/validate_labor_market_examples.py
+
+validate-supply-chain-risk-examples:
+	python3 -m pip install --user jsonschema >/dev/null
+	python3 tools/validate_supply_chain_risk_examples.py
 
 validate-control-plane-examples:
 	python3 -m pip install --user jsonschema >/dev/null

--- a/examples/agent_pod.json
+++ b/examples/agent_pod.json
@@ -1,0 +1,25 @@
+{
+  "id": "urn:srcos:agent-pod:capture-lead",
+  "type": "AgentPod",
+  "specVersion": "2.0.0",
+  "role": "Capture Lead",
+  "mandate": "Own pursuit strategy, buyer map, milestones, and decisions.",
+  "inputs": [
+    "signals",
+    "updates",
+    "Q&A",
+    "competitive intel"
+  ],
+  "outputs": [
+    "pursuit plan",
+    "gate decisions",
+    "action backlog"
+  ],
+  "repoAnchors": [
+    "sociosphere",
+    "socioprophet"
+  ],
+  "status": "active",
+  "choirRole": "governance-sentinel",
+  "agentSessionRef": "urn:srcos:session:capture-lead-run-01"
+}

--- a/examples/capture_cadence.json
+++ b/examples/capture_cadence.json
@@ -1,0 +1,33 @@
+{
+  "id": "urn:srcos:capture-cadence:standard-8wk",
+  "type": "CaptureCadence",
+  "specVersion": "2.0.0",
+  "name": "Standard 8-week capture sprint",
+  "currentWeek": 4,
+  "weeks": [
+    {
+      "week": 0,
+      "objective": "Intake + normalize",
+      "portfolioDeliverable": "update OS, partner map, pod coverage",
+      "cellDeliverable": "opportunity brief + buyer/problem memo",
+      "minReadiness": 0.2,
+      "exitDecision": "pursue / watch / pause"
+    },
+    {
+      "week": 4,
+      "objective": "Artifact pack v1",
+      "portfolioDeliverable": "synchronize all cell artifacts",
+      "cellDeliverable": "30-day artifact pack, storyboard, compliance skeleton",
+      "minReadiness": 0.5,
+      "exitDecision": "Gate 1 complete"
+    },
+    {
+      "week": 8,
+      "objective": "Delta sprint",
+      "portfolioDeliverable": "ingest live text and replan in <=72h",
+      "cellDeliverable": "delta memo, reprioritized backlog, owner resets",
+      "minReadiness": 0.8,
+      "exitDecision": "go-forward after delta"
+    }
+  ]
+}

--- a/examples/capture_delta.json
+++ b/examples/capture_delta.json
@@ -1,0 +1,12 @@
+{
+  "id": "urn:srcos:capture-delta:health-devsecops-qa",
+  "type": "CaptureDelta",
+  "specVersion": "2.0.0",
+  "opportunityRef": "urn:srcos:opportunity:health-devsecops",
+  "kind": "Industry-day Q&A",
+  "monitorSource": "OIT Industry Day site / VOA",
+  "expected": "2026-04-17",
+  "responseSlaHours": 24,
+  "requiredOutput": "delta memo + requirement updates",
+  "status": "Watching"
+}

--- a/examples/fit_score.json
+++ b/examples/fit_score.json
@@ -1,0 +1,17 @@
+{
+  "id": "urn:srcos:fit-score:smelter-audit-0001-r2",
+  "type": "FitScore",
+  "specVersion": "2.0.0",
+  "requestRef": "urn:srcos:labor-request:smelter-audit-0001",
+  "responseRef": "urn:srcos:labor-response:smelter-audit-0001-r2",
+  "rubric": {
+    "domain competence": 0.9,
+    "independence": 1.0,
+    "turnaround": 0.8
+  },
+  "fit": 0.9,
+  "confidence": 0.85,
+  "missingEvidence": [
+    "conflict-of-interest declaration"
+  ]
+}

--- a/examples/labor_award.json
+++ b/examples/labor_award.json
@@ -1,0 +1,31 @@
+{
+  "id": "urn:srcos:labor-award:smelter-audit-0001",
+  "type": "LaborAward",
+  "specVersion": "2.0.0",
+  "requestRef": "urn:srcos:labor-request:smelter-audit-0001",
+  "responseRef": "urn:srcos:labor-response:smelter-audit-0001-r2",
+  "terms": "Fixed $52k, 3 milestones, independence maintained.",
+  "paymentModel": "milestone",
+  "milestones": [
+    {
+      "title": "On-site inspection",
+      "status": "delivered",
+      "proofRef": "urn:srcos:attestation:audit/site"
+    },
+    {
+      "title": "Analysis",
+      "status": "in_progress"
+    },
+    {
+      "title": "Signed report",
+      "status": "pending"
+    }
+  ],
+  "obligations": [
+    "maintain independence",
+    "disclose conflicts"
+  ],
+  "trustEventRefs": [
+    "urn:srcos:trust-event:eng-coop-completion-01"
+  ]
+}

--- a/examples/labor_request.json
+++ b/examples/labor_request.json
@@ -1,0 +1,24 @@
+{
+  "id": "urn:srcos:labor-request:smelter-audit-0001",
+  "type": "LaborRequest",
+  "specVersion": "2.0.0",
+  "requestType": "review",
+  "requesterRef": "urn:srcos:party:chuquicamata-smelter",
+  "objective": "Independent audit of smelter emissions controls before the next regulatory window.",
+  "outcome": "Signed audit report + remediation punch-list.",
+  "compensation": {
+    "transparency": "disclosed",
+    "model": "fixed",
+    "minAmount": 40000,
+    "maxAmount": 60000,
+    "currency": "USD"
+  },
+  "schedule": "3-week engagement",
+  "responseDeadline": "2026-07-20T00:00:00Z",
+  "evaluationCriteria": [
+    "domain competence",
+    "independence",
+    "turnaround"
+  ],
+  "status": "shortlisting"
+}

--- a/examples/labor_response.json
+++ b/examples/labor_response.json
@@ -1,0 +1,15 @@
+{
+  "id": "urn:srcos:labor-response:smelter-audit-0001-r2",
+  "type": "LaborResponse",
+  "specVersion": "2.0.0",
+  "requestRef": "urn:srcos:labor-request:smelter-audit-0001",
+  "responderRef": "urn:srcos:party:eng-cooperative-4471",
+  "approach": "Two-auditor team; on-site week 1, analysis week 2, report week 3.",
+  "terms": "Fixed $52k; independence attested; no prior work for requester.",
+  "proposedPricing": 52000,
+  "availability": "starts 2026-07-22",
+  "evidenceRefs": [
+    "urn:srcos:attestation:eng-coop/prior-audits"
+  ],
+  "status": "shortlisted"
+}

--- a/examples/netting_cell.json
+++ b/examples/netting_cell.json
@@ -1,0 +1,36 @@
+{
+  "id": "urn:srcos:netting-cell:cu-trade-0001",
+  "type": "NettingCell",
+  "specVersion": "2.0.0",
+  "legs": [
+    {
+      "party": "urn:srcos:party:antofagasta-port",
+      "role": "A",
+      "valueRef": "asset://copper-cathode/500t",
+      "proofRef": "urn:srcos:attestation:antofagasta/bill-of-lading"
+    },
+    {
+      "party": "urn:srcos:party:shanghai-buyer",
+      "role": "B",
+      "valueRef": "asset://ASI/1.16M",
+      "capabilityRef": "cap://import-license/cn"
+    },
+    {
+      "party": "urn:srcos:party:clearing-verifier",
+      "role": "C",
+      "proofRef": "urn:srcos:attestation:route-anf-sha/delivery"
+    }
+  ],
+  "stage": "Verified",
+  "truthClass": "ATTESTED",
+  "admissibility": "release",
+  "bundleRefs": [
+    "urn:srcos:triparty-bundle:cu-trade-0001-fill",
+    "urn:srcos:triparty-bundle:cu-trade-0001-verify"
+  ],
+  "policyKernelRef": "policy://triparty/release-guard",
+  "reserveRef": "reserve://asi/primary",
+  "netAmount": 1160000,
+  "asset": "ASI",
+  "supplyChainRef": "hg:route/anf-sha"
+}

--- a/examples/opportunity.json
+++ b/examples/opportunity.json
@@ -1,0 +1,53 @@
+{
+  "id": "urn:srcos:opportunity:health-devsecops",
+  "type": "Opportunity",
+  "specVersion": "2.0.0",
+  "name": "Health Services DevSecOps",
+  "cluster": "Health",
+  "missionOwner": "PDS",
+  "buyingProblem": "Sustain legacy health apps while modernizing safely outside the Oracle Health baseline.",
+  "priorities": [
+    "VistA sustainment",
+    "modernization",
+    "MUMPS"
+  ],
+  "deliveryPattern": "Continuity-plus-modernization delivery cell; governed DevSecOps; legacy transition discipline.",
+  "reuseRepos": [
+    "prophet-platform",
+    "prophet-platform-standards",
+    "agentplane",
+    "policy-fabric",
+    "sociosphere"
+  ],
+  "podRefs": [
+    "urn:srcos:agent-pod:capture-lead",
+    "urn:srcos:agent-pod:technical-solution",
+    "urn:srcos:agent-pod:compliance-matrix",
+    "urn:srcos:agent-pod:evidence-qa"
+  ],
+  "sharedLibraryRefs": [
+    "urn:srcos:shared-library:canonical-operating-model",
+    "urn:srcos:shared-library:transition-in",
+    "urn:srcos:shared-library:release-gates"
+  ],
+  "readinessRef": "urn:srcos:readiness-score:health-devsecops",
+  "deltaRefs": [
+    "urn:srcos:capture-delta:health-devsecops-qa"
+  ],
+  "partnerLane": "Health IT SI; VistA/MUMPS niche partner",
+  "winTheme": "We preserve continuity while industrializing governed modernization with low-regret migration paths.",
+  "status": "Active",
+  "workroomRef": "workroom://health-devsecops",
+  "controlRoomRef": "controlroom://health-devsecops",
+  "telos": {
+    "objective": "Intelligence serves human flourishing",
+    "constraints": [
+      "non-domination",
+      "consent",
+      "dignity"
+    ]
+  },
+  "evidenceRefs": [
+    "urn:srcos:attestation:health-devsecops/win-theme"
+  ]
+}

--- a/examples/readiness_score.json
+++ b/examples/readiness_score.json
@@ -1,0 +1,29 @@
+{
+  "id": "urn:srcos:readiness-score:health-devsecops",
+  "type": "ReadinessScore",
+  "specVersion": "2.0.0",
+  "opportunityRef": "urn:srcos:opportunity:health-devsecops",
+  "dimensions": {
+    "buyerProblem": 3,
+    "solutionHypothesis": 2,
+    "sharedLibraries": 3,
+    "agentPod": 2,
+    "partnerArchetype": 2,
+    "namedPartnerTargets": 0,
+    "oemLane": 1,
+    "artifactPack": 2,
+    "deltaControl": 2,
+    "questions": 1,
+    "pricing": 0,
+    "pastPerformance": 0
+  },
+  "total": 18,
+  "max": 36,
+  "readinessPct": 50,
+  "rag": "Amber",
+  "nextGate": "Gate 1",
+  "evidenceRefs": [
+    "urn:srcos:attestation:health-devsecops/buyer-problem"
+  ],
+  "policyRef": "policy://capture/burden-of-proof/gate-1"
+}

--- a/examples/risk_cluster.json
+++ b/examples/risk_cluster.json
@@ -1,0 +1,18 @@
+{
+  "id": "urn:srcos:risk-cluster:trans-pacific-shipping",
+  "type": "RiskCluster",
+  "specVersion": "2.0.0",
+  "clusterName": "Trans-Pacific shipping lanes",
+  "clusterType": "Logistics / route concentration",
+  "providerShares": [
+    0.55,
+    0.25,
+    0.2
+  ],
+  "hhi": 0.39,
+  "blastRadius": 0.6,
+  "timeToRecover": 0.5,
+  "exitDifficulty": 0.7,
+  "residualCommonMode": 0.52,
+  "rating": "High"
+}

--- a/examples/risk_indicator.json
+++ b/examples/risk_indicator.json
@@ -1,0 +1,15 @@
+{
+  "id": "urn:srcos:risk-indicator:tier0-provenance",
+  "type": "RiskIndicator",
+  "specVersion": "2.0.0",
+  "indicatorType": "KRI",
+  "metric": "Tier-0 nodes with verified provenance",
+  "definition": "Share of tier-0 supply-chain nodes with verified provenance attached before admission.",
+  "value": 0.82,
+  "green": ">=95%",
+  "amber": "80-94.9%",
+  "red": "<80%",
+  "band": "amber",
+  "frequency": "Weekly",
+  "owner": "Supply Chain Risk"
+}

--- a/examples/risk_node.json
+++ b/examples/risk_node.json
@@ -1,0 +1,30 @@
+{
+  "id": "urn:srcos:risk-node:escondida",
+  "type": "RiskNode",
+  "specVersion": "2.0.0",
+  "nodeRef": "hg:facility/escondida",
+  "criticalService": "Copper cathode supply",
+  "inherent": {
+    "criticality": 0.9,
+    "privilege": 0.4,
+    "execution": 0.2,
+    "opacity": 0.5,
+    "concentration": 0.8,
+    "velocity": 0.3
+  },
+  "inherentScore": 0.62,
+  "controls": {
+    "governance": 0.7,
+    "identityPublish": 0.5,
+    "provenance": 0.6,
+    "integrity": 0.6,
+    "distribution": 0.4,
+    "monitoring": 0.6
+  },
+  "residualScore": 0.34,
+  "rating": "Medium",
+  "controlGaps": [
+    "distribution"
+  ],
+  "note": "World's largest copper mine — high criticality + concentration; water is the swing risk."
+}

--- a/examples/risk_path.json
+++ b/examples/risk_path.json
@@ -1,0 +1,15 @@
+{
+  "id": "urn:srcos:risk-path:copper-cathode",
+  "type": "RiskPath",
+  "specVersion": "2.0.0",
+  "criticalService": "Copper cathode · Antofagasta → Shanghai",
+  "serviceOwner": "Copper Capital Syndicate",
+  "nodeRefs": [
+    "urn:srcos:risk-node:escondida",
+    "urn:srcos:risk-node:antofagasta-port",
+    "urn:srcos:risk-node:route-anf-sha"
+  ],
+  "pathRisk": 0.48,
+  "rating": "High",
+  "impactTolerance": "< 2 weeks"
+}

--- a/examples/shared_library.json
+++ b/examples/shared_library.json
@@ -1,0 +1,13 @@
+{
+  "id": "urn:srcos:shared-library:release-gates",
+  "type": "SharedLibrary",
+  "specVersion": "2.0.0",
+  "name": "Quality / release gates",
+  "standardizes": "Validation, test automation, release readiness, defect policy.",
+  "repoAnchors": [
+    "agentplane",
+    "prophet-platform-standards",
+    "sourceos-spec"
+  ],
+  "usedBy": "All build/run objectives"
+}

--- a/examples/triparty_bundle.json
+++ b/examples/triparty_bundle.json
@@ -1,0 +1,16 @@
+{
+  "id": "urn:srcos:triparty-bundle:cu-trade-0001-verify",
+  "type": "TripartyBundle",
+  "specVersion": "2.0.0",
+  "kind": "verification",
+  "cellRef": "urn:srcos:netting-cell:cu-trade-0001",
+  "payload": {
+    "verifier": "clearing-verifier",
+    "result": "delivery-confirmed",
+    "scope": "route-anf-sha"
+  },
+  "proofRef": "urn:srcos:proof:cu-trade-0001/state",
+  "attestationRef": "urn:srcos:attestation:route-anf-sha/delivery",
+  "truthClass": "ATTESTED",
+  "issuedAt": "2026-07-03T18:00:00Z"
+}

--- a/examples/trust_event.json
+++ b/examples/trust_event.json
@@ -1,0 +1,10 @@
+{
+  "id": "urn:srcos:trust-event:eng-coop-completion-01",
+  "type": "TrustEvent",
+  "specVersion": "2.0.0",
+  "subjectRef": "urn:srcos:party:eng-cooperative-4471",
+  "kind": "completion",
+  "requestRef": "urn:srcos:labor-request:smelter-audit-0001",
+  "evidenceRef": "urn:srcos:attestation:audit/site",
+  "issuedAt": "2026-07-25T00:00:00Z"
+}

--- a/schemas/AgentPod.json
+++ b/schemas/AgentPod.json
@@ -1,0 +1,91 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.srcos.ai/v2/AgentPod.json",
+  "title": "AgentPod",
+  "description": "A standard agent pod: a named role with a mandate, typed inputs/outputs, and repo anchors. The unit of staffing in the agentic operating system; the pod URN is the same one referenced by AgentMachineReceipt.agentPodRef.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "id",
+    "type",
+    "specVersion",
+    "role",
+    "mandate",
+    "inputs",
+    "outputs",
+    "repoAnchors"
+  ],
+  "properties": {
+    "id": {
+      "type": "string",
+      "pattern": "^urn:srcos:agent-pod:",
+      "description": "Stable URN identifier. Pattern: urn:srcos:agent-pod:<local-id>"
+    },
+    "type": {
+      "const": "AgentPod",
+      "description": "Discriminator constant — always \"AgentPod\"."
+    },
+    "specVersion": {
+      "type": "string",
+      "description": "Spec version of this document, e.g. \"2.0.0\"."
+    },
+    "role": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Human role name, e.g. \"Capture Lead\"."
+    },
+    "mandate": {
+      "type": "string",
+      "minLength": 1,
+      "description": "What the pod owns."
+    },
+    "inputs": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "description": "Core inputs the pod consumes."
+    },
+    "outputs": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "description": "Core artifacts the pod produces."
+    },
+    "repoAnchors": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "description": "Estate repositories this pod's patterns anchor to."
+    },
+    "status": {
+      "type": "string",
+      "enum": [
+        "active",
+        "shadow",
+        "paused"
+      ],
+      "description": "Operational status of the pod."
+    },
+    "choirRole": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "description": "prophet-mesh agent-choir role this pod aligns to (e.g. \"planning-agent\", \"governance-sentinel\"). The choir is the canonical role vocabulary; this pod is its capture-side projection."
+    },
+    "agentSessionRef": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "pattern": "^urn:srcos:session:",
+      "description": "The AgentSession URN when this pod is executing (the Perceive→Reason→Act→Verify loop)."
+    }
+  }
+}

--- a/schemas/CaptureCadence.json
+++ b/schemas/CaptureCadence.json
@@ -1,0 +1,75 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.srcos.ai/v2/CaptureCadence.json",
+  "title": "CaptureCadence",
+  "description": "The governed capture cadence: a fixed sprint of weeks, each with objectives, deliverables, a minimum-readiness gate, and an exit decision.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "id",
+    "type",
+    "specVersion",
+    "weeks"
+  ],
+  "properties": {
+    "id": {
+      "type": "string",
+      "pattern": "^urn:srcos:capture-cadence:",
+      "description": "Stable URN identifier. Pattern: urn:srcos:capture-cadence:<local-id>"
+    },
+    "type": {
+      "const": "CaptureCadence",
+      "description": "Discriminator constant — always \"CaptureCadence\"."
+    },
+    "specVersion": {
+      "type": "string",
+      "description": "Spec version of this document, e.g. \"2.0.0\"."
+    },
+    "name": {
+      "type": "string"
+    },
+    "weeks": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "week",
+          "objective",
+          "minReadiness",
+          "exitDecision"
+        ],
+        "properties": {
+          "week": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "objective": {
+            "type": "string"
+          },
+          "portfolioDeliverable": {
+            "type": "string"
+          },
+          "cellDeliverable": {
+            "type": "string"
+          },
+          "minReadiness": {
+            "type": "number",
+            "minimum": 0,
+            "maximum": 1
+          },
+          "exitDecision": {
+            "type": "string"
+          }
+        }
+      },
+      "description": "Ordered cadence weeks."
+    },
+    "currentWeek": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Where the portfolio currently sits."
+    }
+  }
+}

--- a/schemas/CaptureDelta.json
+++ b/schemas/CaptureDelta.json
@@ -1,0 +1,67 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.srcos.ai/v2/CaptureDelta.json",
+  "title": "CaptureDelta",
+  "description": "A standing delta-control monitor for an objective: an event source watched under an SLA, with a required response artifact.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "id",
+    "type",
+    "specVersion",
+    "opportunityRef",
+    "kind",
+    "monitorSource",
+    "status",
+    "requiredOutput"
+  ],
+  "properties": {
+    "id": {
+      "type": "string",
+      "pattern": "^urn:srcos:capture-delta:",
+      "description": "Stable URN identifier. Pattern: urn:srcos:capture-delta:<local-id>"
+    },
+    "type": {
+      "const": "CaptureDelta",
+      "description": "Discriminator constant — always \"CaptureDelta\"."
+    },
+    "specVersion": {
+      "type": "string",
+      "description": "Spec version of this document, e.g. \"2.0.0\"."
+    },
+    "opportunityRef": {
+      "type": "string",
+      "pattern": "^urn:srcos:opportunity:"
+    },
+    "kind": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Delta type, e.g. \"Industry-day Q&A\", \"Draft RFP\", \"Amendment\"."
+    },
+    "monitorSource": {
+      "type": "string",
+      "minLength": 1
+    },
+    "expected": {
+      "type": "string",
+      "description": "Expected/observed date (ISO date or \"TBD\")."
+    },
+    "responseSlaHours": {
+      "type": "number",
+      "minimum": 0,
+      "description": "Response SLA in hours once the delta lands."
+    },
+    "requiredOutput": {
+      "type": "string",
+      "minLength": 1
+    },
+    "status": {
+      "type": "string",
+      "enum": [
+        "Open",
+        "Watching",
+        "Ingested"
+      ]
+    }
+  }
+}

--- a/schemas/FitScore.json
+++ b/schemas/FitScore.json
@@ -1,0 +1,69 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.srcos.ai/v2/FitScore.json",
+  "title": "FitScore",
+  "description": "Scores the FIT between a specific request and a specific response. By charter rule the platform scores request↔response fit and MUST NOT publish a universal human-worth / global employability score — hence requestRef AND responseRef are both required and there is no subject-only score.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "id",
+    "type",
+    "specVersion",
+    "requestRef",
+    "responseRef",
+    "fit"
+  ],
+  "properties": {
+    "id": {
+      "type": "string",
+      "pattern": "^urn:srcos:fit-score:",
+      "description": "Stable URN. Pattern: urn:srcos:fit-score:<local-id>"
+    },
+    "type": {
+      "const": "FitScore",
+      "description": "Discriminator — always \"FitScore\"."
+    },
+    "specVersion": {
+      "type": "string",
+      "description": "Spec version, e.g. \"2.0.0\"."
+    },
+    "requestRef": {
+      "type": "string",
+      "pattern": "^urn:srcos:labor-request:",
+      "description": "Required — fit is always request-scoped."
+    },
+    "responseRef": {
+      "type": "string",
+      "pattern": "^urn:srcos:labor-response:",
+      "description": "Required — fit is always response-scoped. No global score exists."
+    },
+    "rubric": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "number",
+        "minimum": 0,
+        "maximum": 1
+      },
+      "description": "Per-dimension fit (0..1) against the request's evaluation criteria."
+    },
+    "fit": {
+      "type": "number",
+      "minimum": 0,
+      "maximum": 1,
+      "description": "Overall request↔response fit (0..1)."
+    },
+    "confidence": {
+      "type": "number",
+      "minimum": 0,
+      "maximum": 1
+    },
+    "missingEvidence": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "description": "Evidence the reviewer still needs to raise confidence."
+    }
+  }
+}

--- a/schemas/LaborAward.json
+++ b/schemas/LaborAward.json
@@ -1,0 +1,103 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.srcos.ai/v2/LaborAward.json",
+  "title": "LaborAward",
+  "description": "The accepted working arrangement — records the selected response, terms, milestones, payment model, and obligations, and anchors the work ledger that tracks fulfillment.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "id",
+    "type",
+    "specVersion",
+    "requestRef",
+    "responseRef",
+    "terms",
+    "paymentModel"
+  ],
+  "properties": {
+    "id": {
+      "type": "string",
+      "pattern": "^urn:srcos:labor-award:",
+      "description": "Stable URN. Pattern: urn:srcos:labor-award:<local-id>"
+    },
+    "type": {
+      "const": "LaborAward",
+      "description": "Discriminator — always \"LaborAward\"."
+    },
+    "specVersion": {
+      "type": "string",
+      "description": "Spec version, e.g. \"2.0.0\"."
+    },
+    "requestRef": {
+      "type": "string",
+      "pattern": "^urn:srcos:labor-request:"
+    },
+    "responseRef": {
+      "type": "string",
+      "pattern": "^urn:srcos:labor-response:"
+    },
+    "terms": {
+      "type": "string",
+      "minLength": 1
+    },
+    "paymentModel": {
+      "type": "string",
+      "enum": [
+        "fixed",
+        "hourly",
+        "milestone",
+        "equity",
+        "stipend"
+      ]
+    },
+    "milestones": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "title",
+          "status"
+        ],
+        "properties": {
+          "title": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "pending",
+              "in_progress",
+              "delivered",
+              "approved",
+              "disputed"
+            ]
+          },
+          "proofRef": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        }
+      }
+    },
+    "obligations": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "description": "Obligations both parties accept."
+    },
+    "trustEventRefs": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1,
+        "pattern": "^urn:srcos:trust-event:"
+      },
+      "description": "Trust events emitted over the life of the award."
+    }
+  }
+}

--- a/schemas/LaborRequest.json
+++ b/schemas/LaborRequest.json
@@ -1,0 +1,138 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.srcos.ai/v2/LaborRequest.json",
+  "title": "LaborRequest",
+  "description": "A structured labor request — the primary unit of the request-and-fulfillment network. NOT a generic post. Every request declares objective, outcome, compensation, schedule, deadline, and evaluation criteria (LN-003); compensation transparency is mandatory except volunteer/mutual-aid/exploratory (LN-004).",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "id",
+    "type",
+    "specVersion",
+    "requestType",
+    "requesterRef",
+    "objective",
+    "outcome",
+    "compensation",
+    "responseDeadline",
+    "evaluationCriteria"
+  ],
+  "properties": {
+    "id": {
+      "type": "string",
+      "pattern": "^urn:srcos:labor-request:",
+      "description": "Stable URN. Pattern: urn:srcos:labor-request:<local-id>"
+    },
+    "type": {
+      "const": "LaborRequest",
+      "description": "Discriminator — always \"LaborRequest\"."
+    },
+    "specVersion": {
+      "type": "string",
+      "description": "Spec version, e.g. \"2.0.0\"."
+    },
+    "requestType": {
+      "type": "string",
+      "enum": [
+        "RFI",
+        "RFP",
+        "RFQ",
+        "role",
+        "collaboration",
+        "apprenticeship",
+        "review",
+        "availability"
+      ],
+      "description": "Typed ask: RFI/RFP/RFQ/role/collaboration/apprenticeship/review/availability (LN-002)."
+    },
+    "requesterRef": {
+      "type": "string",
+      "description": "The requester (introduces demand)."
+    },
+    "objective": {
+      "type": "string",
+      "minLength": 1
+    },
+    "outcome": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Expected deliverable or outcome."
+    },
+    "compensation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "transparency"
+      ],
+      "properties": {
+        "transparency": {
+          "type": "string",
+          "enum": [
+            "disclosed",
+            "exempt"
+          ],
+          "description": "Compensation SHALL be disclosed except where the request is volunteer, mutual-aid, or exploratory (LN-004)."
+        },
+        "exemptReason": {
+          "type": "string",
+          "enum": [
+            "volunteer",
+            "mutual-aid",
+            "exploratory"
+          ],
+          "description": "Required when transparency=exempt."
+        },
+        "model": {
+          "type": "string",
+          "enum": [
+            "fixed",
+            "hourly",
+            "milestone",
+            "equity",
+            "stipend"
+          ]
+        },
+        "minAmount": {
+          "type": "number",
+          "minimum": 0
+        },
+        "maxAmount": {
+          "type": "number",
+          "minimum": 0
+        },
+        "currency": {
+          "type": "string"
+        }
+      }
+    },
+    "schedule": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "description": "Schedule expectations."
+    },
+    "responseDeadline": {
+      "type": "string",
+      "description": "ISO-8601 response deadline."
+    },
+    "evaluationCriteria": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "description": "How responses are evaluated (fit, not popularity)."
+    },
+    "status": {
+      "type": "string",
+      "enum": [
+        "open",
+        "shortlisting",
+        "awarded",
+        "closed",
+        "withdrawn"
+      ]
+    }
+  }
+}

--- a/schemas/LaborResponse.json
+++ b/schemas/LaborResponse.json
@@ -1,0 +1,81 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.srcos.ai/v2/LaborResponse.json",
+  "title": "LaborResponse",
+  "description": "A structured response to a LaborRequest — a proposal, quote, expression of interest, or availability signal with evidence. Trial work that produces usable value SHALL be compensated (LN-005).",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "id",
+    "type",
+    "specVersion",
+    "requestRef",
+    "responderRef",
+    "approach"
+  ],
+  "properties": {
+    "id": {
+      "type": "string",
+      "pattern": "^urn:srcos:labor-response:",
+      "description": "Stable URN. Pattern: urn:srcos:labor-response:<local-id>"
+    },
+    "type": {
+      "const": "LaborResponse",
+      "description": "Discriminator — always \"LaborResponse\"."
+    },
+    "specVersion": {
+      "type": "string",
+      "description": "Spec version, e.g. \"2.0.0\"."
+    },
+    "requestRef": {
+      "type": "string",
+      "pattern": "^urn:srcos:labor-request:",
+      "description": "The request this answers."
+    },
+    "responderRef": {
+      "type": "string",
+      "description": "The worker/team (introduces supply)."
+    },
+    "approach": {
+      "type": "string",
+      "minLength": 1
+    },
+    "terms": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "proposedPricing": {
+      "type": [
+        "number",
+        "null"
+      ],
+      "minimum": 0
+    },
+    "availability": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "evidenceRefs": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "description": "Evidence packets / fulfillment records backing the response — not follower counts."
+    },
+    "status": {
+      "type": "string",
+      "enum": [
+        "submitted",
+        "shortlisted",
+        "declined",
+        "awarded",
+        "withdrawn"
+      ]
+    }
+  }
+}

--- a/schemas/NettingCell.json
+++ b/schemas/NettingCell.json
@@ -1,0 +1,163 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.srcos.ai/v2/NettingCell.json",
+  "title": "NettingCell",
+  "description": "A governed triparty netting cell — the smallest local clearing object that couples value, proof, authority, and disclosure. Cancels interior circulation across three legs and governs release/refund/export by policy rather than confidence alone.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "id",
+    "type",
+    "specVersion",
+    "legs",
+    "stage",
+    "truthClass",
+    "admissibility"
+  ],
+  "properties": {
+    "id": {
+      "type": "string",
+      "pattern": "^urn:srcos:netting-cell:",
+      "description": "Stable URN identifier. Pattern: urn:srcos:netting-cell:<local-id>"
+    },
+    "type": {
+      "const": "NettingCell",
+      "description": "Discriminator constant — always \"NettingCell\"."
+    },
+    "specVersion": {
+      "type": "string",
+      "description": "Spec version, e.g. \"2.0.0\"."
+    },
+    "legs": {
+      "type": "array",
+      "minItems": 3,
+      "maxItems": 3,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "party",
+          "role"
+        ],
+        "properties": {
+          "party": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Party URN / identifier for this leg."
+          },
+          "role": {
+            "type": "string",
+            "enum": [
+              "A",
+              "B",
+              "C"
+            ],
+            "description": "Triparty leg role (A, B are counterparties; C is the clearing/verifier leg)."
+          },
+          "valueRef": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "The monetary/asset value this leg carries into the cell."
+          },
+          "capabilityRef": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "The capability right this leg carries (from the CapabilityRegistry) — kept distinct from value."
+          },
+          "proofRef": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "The proof/attestation this leg carries (Truth Engine) — evidence distinct from permission."
+          }
+        }
+      },
+      "description": "The three triparty legs (A, B counterparties; C clearing/verifier)."
+    },
+    "stage": {
+      "type": "string",
+      "enum": [
+        "Observed",
+        "Proposed",
+        "Ready",
+        "Escrowed",
+        "Filled",
+        "Verified",
+        "Released",
+        "Exported",
+        "Refunded",
+        "Reversed"
+      ],
+      "description": "Lifecycle stage: Observed→Proposed→Ready→Escrowed→Filled→Verified→Released→(Exported); or Refunded/Reversed."
+    },
+    "truthClass": {
+      "type": "string",
+      "enum": [
+        "PROVEN",
+        "ATTESTED",
+        "INFERRED",
+        "REPUTED"
+      ],
+      "description": "Truth class of the cell's current state (constitution): PROVEN⊐ATTESTED⊐INFERRED⊐REPUTED."
+    },
+    "admissibility": {
+      "type": "string",
+      "enum": [
+        "evidence",
+        "admit",
+        "release",
+        "export"
+      ],
+      "description": "Current admissibility ceiling on the lattice evidence⊇admit⊇release⊇export. Export is stricter than local validity."
+    },
+    "bundleRefs": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1,
+        "pattern": "^urn:srcos:triparty-bundle:"
+      },
+      "description": "The typed bundles that moved this cell through its lifecycle."
+    },
+    "policyKernelRef": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "description": "The PolicyKernel that disposes release/refund/export (policy disposes; evidence proposes; proof preserves)."
+    },
+    "reserveRef": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "description": "ReserveManager reference backing settlement."
+    },
+    "netAmount": {
+      "type": [
+        "number",
+        "null"
+      ],
+      "description": "Net residual after interior cancellation."
+    },
+    "asset": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "description": "Settlement asset / token (e.g. ASI/FET)."
+    },
+    "supplyChainRef": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "description": "Optional hg: / node ref when this cell clears a supply-chain trade."
+    }
+  }
+}

--- a/schemas/Opportunity.json
+++ b/schemas/Opportunity.json
@@ -1,0 +1,161 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.srcos.ai/v2/Opportunity.json",
+  "title": "Opportunity",
+  "description": "An objective the agentic operating system pursues: the normalized operating fields for a pursuit, anchored to estate repos, agent pods, shared libraries, a readiness scorecard, and delta monitors.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "id",
+    "type",
+    "specVersion",
+    "name",
+    "cluster",
+    "buyingProblem",
+    "status"
+  ],
+  "properties": {
+    "id": {
+      "type": "string",
+      "pattern": "^urn:srcos:opportunity:",
+      "description": "Stable URN identifier. Pattern: urn:srcos:opportunity:<local-id>"
+    },
+    "type": {
+      "const": "Opportunity",
+      "description": "Discriminator constant — always \"Opportunity\"."
+    },
+    "specVersion": {
+      "type": "string",
+      "description": "Spec version of this document, e.g. \"2.0.0\"."
+    },
+    "name": {
+      "type": "string",
+      "minLength": 1
+    },
+    "cluster": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Portfolio cluster, e.g. \"Health\", \"Cyber\"."
+    },
+    "missionOwner": {
+      "type": "string"
+    },
+    "buyingProblem": {
+      "type": "string",
+      "minLength": 1
+    },
+    "priorities": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "description": "Priorities / burning issues."
+    },
+    "deliveryPattern": {
+      "type": "string",
+      "description": "Primary delivery-excellence pattern."
+    },
+    "reuseRepos": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "description": "Adjacent estate repositories to reuse."
+    },
+    "podRefs": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1,
+        "pattern": "^urn:srcos:agent-pod:"
+      },
+      "description": "Agent pods emphasized for this objective."
+    },
+    "sharedLibraryRefs": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1,
+        "pattern": "^urn:srcos:shared-library:"
+      },
+      "description": "Shared libraries inherited."
+    },
+    "readinessRef": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "pattern": "^urn:srcos:readiness-score:",
+      "description": "The readiness scorecard for this objective."
+    },
+    "deltaRefs": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1,
+        "pattern": "^urn:srcos:capture-delta:"
+      },
+      "description": "Standing delta monitors."
+    },
+    "partnerLane": {
+      "type": "string"
+    },
+    "winTheme": {
+      "type": "string"
+    },
+    "status": {
+      "type": "string",
+      "enum": [
+        "Active",
+        "Watch",
+        "Paused"
+      ]
+    },
+    "workroomRef": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "description": "prophet-workspace ProfessionalWorkroom backing this objective (the objective/pursuit container). Composition, not duplication — the workroom owns context/policy/artifacts/tasks/evidence."
+    },
+    "controlRoomRef": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "description": "prophet-workspace OrgGovControlRoom governing this objective (Objective→Actor→Role→Policy→Asset→Action→Evidence→Review→Outcome→Score→Learning)."
+    },
+    "telos": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "objective"
+      ],
+      "properties": {
+        "objective": {
+          "type": "string",
+          "description": "The end this objective serves, under the Telos layer (e.g. intelligence serves human flourishing)."
+        },
+        "constraints": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "description": "Binding constraints that set weights/thresholds and burden-of-proof — e.g. non-domination, consent, dignity. Sets thresholds; does not assert truth."
+        }
+      },
+      "description": "Telos layer: objective + constraints. Sets the burden of proof; per the governance constitution it cannot assert truth — that is the Truth Engine's role."
+    },
+    "evidenceRefs": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "description": "Truth Engine attestation/evidence records (Witness/Attestation → Truth Record) supporting this objective's claims."
+    }
+  }
+}

--- a/schemas/ReadinessScore.json
+++ b/schemas/ReadinessScore.json
@@ -1,0 +1,159 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.srcos.ai/v2/ReadinessScore.json",
+  "title": "ReadinessScore",
+  "description": "A 12-dimension readiness scorecard for an objective. Each dimension is 0..3 (0=not started, 3=review-ready with named owner/partner evidence); total 0..36.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "id",
+    "type",
+    "specVersion",
+    "opportunityRef",
+    "dimensions",
+    "total",
+    "rag",
+    "nextGate"
+  ],
+  "properties": {
+    "id": {
+      "type": "string",
+      "pattern": "^urn:srcos:readiness-score:",
+      "description": "Stable URN identifier. Pattern: urn:srcos:readiness-score:<local-id>"
+    },
+    "type": {
+      "const": "ReadinessScore",
+      "description": "Discriminator constant — always \"ReadinessScore\"."
+    },
+    "specVersion": {
+      "type": "string",
+      "description": "Spec version of this document, e.g. \"2.0.0\"."
+    },
+    "opportunityRef": {
+      "type": "string",
+      "pattern": "^urn:srcos:opportunity:",
+      "description": "The objective this scorecard grades."
+    },
+    "dimensions": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "buyerProblem",
+        "solutionHypothesis",
+        "sharedLibraries",
+        "agentPod",
+        "partnerArchetype",
+        "namedPartnerTargets",
+        "oemLane",
+        "artifactPack",
+        "deltaControl",
+        "questions",
+        "pricing",
+        "pastPerformance"
+      ],
+      "properties": {
+        "buyerProblem": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 3
+        },
+        "solutionHypothesis": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 3
+        },
+        "sharedLibraries": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 3
+        },
+        "agentPod": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 3
+        },
+        "partnerArchetype": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 3
+        },
+        "namedPartnerTargets": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 3
+        },
+        "oemLane": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 3
+        },
+        "artifactPack": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 3
+        },
+        "deltaControl": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 3
+        },
+        "questions": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 3
+        },
+        "pricing": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 3
+        },
+        "pastPerformance": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 3
+        }
+      },
+      "description": "The 12 readiness dimensions, each scored 0..3."
+    },
+    "total": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 36
+    },
+    "max": {
+      "const": 36
+    },
+    "readinessPct": {
+      "type": "number",
+      "minimum": 0,
+      "maximum": 100
+    },
+    "rag": {
+      "type": "string",
+      "enum": [
+        "Red",
+        "Amber",
+        "Green"
+      ]
+    },
+    "nextGate": {
+      "type": "string",
+      "description": "The next capture gate, e.g. \"Gate 1\"."
+    },
+    "evidenceRefs": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "description": "Truth Engine attestations backing the scored dimensions — a dimension advances only when its claim earns a Truth Record (burden-of-proof gate, not a self-asserted number)."
+    },
+    "policyRef": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "description": "The Da'at policy interface defining what counts as acceptable proof for these gates."
+    }
+  }
+}

--- a/schemas/RiskCluster.json
+++ b/schemas/RiskCluster.json
@@ -1,0 +1,90 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.srcos.ai/v2/RiskCluster.json",
+  "title": "RiskCluster",
+  "description": "Common-mode / concentration cluster risk — correlated dependencies (a shared registry, CI provider, identity broker, model provider, or control plane). HHI measures concentration; blast radius, time-to-recover, and exit-difficulty size the systemic exposure.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "id",
+    "type",
+    "specVersion",
+    "clusterName",
+    "hhi",
+    "residualCommonMode",
+    "rating"
+  ],
+  "properties": {
+    "id": {
+      "type": "string",
+      "pattern": "^urn:srcos:risk-cluster:",
+      "description": "Stable URN. Pattern: urn:srcos:risk-cluster:<local-id>"
+    },
+    "type": {
+      "const": "RiskCluster",
+      "description": "Discriminator — always \"RiskCluster\"."
+    },
+    "specVersion": {
+      "type": "string",
+      "description": "Spec version, e.g. \"2.0.0\"."
+    },
+    "clusterName": {
+      "type": "string",
+      "minLength": 1
+    },
+    "clusterType": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "providerShares": {
+      "type": "array",
+      "items": {
+        "type": "number",
+        "minimum": 0,
+        "maximum": 1
+      },
+      "description": "Market/dependency share per provider (for HHI)."
+    },
+    "hhi": {
+      "type": "number",
+      "minimum": 0,
+      "maximum": 1,
+      "description": "Herfindahl-Hirschman concentration index (normalized 0..1)."
+    },
+    "blastRadius": {
+      "type": "number",
+      "minimum": 0,
+      "maximum": 1,
+      "description": "Fraction of the estate affected if the cluster fails."
+    },
+    "timeToRecover": {
+      "type": "number",
+      "minimum": 0,
+      "maximum": 1,
+      "description": "Normalized recovery time (0=fast, 1=slow)."
+    },
+    "exitDifficulty": {
+      "type": "number",
+      "minimum": 0,
+      "maximum": 1,
+      "description": "How hard it is to switch away (lock-in)."
+    },
+    "residualCommonMode": {
+      "type": "number",
+      "minimum": 0,
+      "maximum": 1,
+      "description": "Residual common-mode risk after resilience controls."
+    },
+    "rating": {
+      "type": "string",
+      "enum": [
+        "Low",
+        "Medium",
+        "High",
+        "Critical"
+      ]
+    }
+  }
+}

--- a/schemas/RiskIndicator.json
+++ b/schemas/RiskIndicator.json
@@ -1,0 +1,95 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.srcos.ai/v2/RiskIndicator.json",
+  "title": "RiskIndicator",
+  "description": "A key risk indicator (KRI) or key control indicator (KCI) with green/amber/red thresholds, tracked against risk appetite.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "id",
+    "type",
+    "specVersion",
+    "indicatorType",
+    "metric"
+  ],
+  "properties": {
+    "id": {
+      "type": "string",
+      "pattern": "^urn:srcos:risk-indicator:",
+      "description": "Stable URN. Pattern: urn:srcos:risk-indicator:<local-id>"
+    },
+    "type": {
+      "const": "RiskIndicator",
+      "description": "Discriminator — always \"RiskIndicator\"."
+    },
+    "specVersion": {
+      "type": "string",
+      "description": "Spec version, e.g. \"2.0.0\"."
+    },
+    "indicatorType": {
+      "type": "string",
+      "enum": [
+        "KRI",
+        "KCI"
+      ]
+    },
+    "metric": {
+      "type": "string",
+      "minLength": 1
+    },
+    "definition": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "value": {
+      "type": [
+        "number",
+        "null"
+      ]
+    },
+    "green": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "amber": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "red": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "band": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "green",
+        "amber",
+        "red",
+        null
+      ]
+    },
+    "frequency": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "owner": {
+      "type": [
+        "string",
+        "null"
+      ]
+    }
+  }
+}

--- a/schemas/RiskNode.json
+++ b/schemas/RiskNode.json
@@ -1,0 +1,176 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.srcos.ai/v2/RiskNode.json",
+  "title": "RiskNode",
+  "description": "Operational-risk assessment of a single supply-chain node. Inherent risk factors (criticality, privilege, execution, opacity, concentration, velocity) combine to an inherent score; control efficacy across six control families reduces it to a residual score + rating. Aligns to BIAN Operational Risk Models.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "id",
+    "type",
+    "specVersion",
+    "nodeRef",
+    "inherent",
+    "inherentScore",
+    "residualScore",
+    "rating"
+  ],
+  "properties": {
+    "id": {
+      "type": "string",
+      "pattern": "^urn:srcos:risk-node:",
+      "description": "Stable URN. Pattern: urn:srcos:risk-node:<local-id>"
+    },
+    "type": {
+      "const": "RiskNode",
+      "description": "Discriminator — always \"RiskNode\"."
+    },
+    "specVersion": {
+      "type": "string",
+      "description": "Spec version, e.g. \"2.0.0\"."
+    },
+    "nodeRef": {
+      "type": "string",
+      "description": "The supply-chain node/facility/route this assesses (e.g. an hg: ref)."
+    },
+    "criticalService": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "description": "The critical service this node participates in."
+    },
+    "inherent": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "criticality",
+        "privilege",
+        "execution",
+        "opacity",
+        "concentration",
+        "velocity"
+      ],
+      "properties": {
+        "criticality": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1,
+          "description": "K — how critical the node is to a critical service."
+        },
+        "privilege": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1,
+          "description": "P — authority/privilege the node holds."
+        },
+        "execution": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1,
+          "description": "E — code/execution exposure."
+        },
+        "opacity": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1,
+          "description": "O — how opaque/unverifiable the node is."
+        },
+        "concentration": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1,
+          "description": "C — single-point / concentration."
+        },
+        "velocity": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1,
+          "description": "V — change velocity / blast speed."
+        }
+      }
+    },
+    "inherentScore": {
+      "type": "number",
+      "minimum": 0,
+      "maximum": 1,
+      "description": "Weighted inherent risk (0..1)."
+    },
+    "controls": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "governance",
+        "identityPublish",
+        "provenance",
+        "integrity",
+        "distribution",
+        "monitoring"
+      ],
+      "properties": {
+        "governance": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1,
+          "description": "governance control efficacy (0=none, 1=strong)."
+        },
+        "identityPublish": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1,
+          "description": "identityPublish control efficacy (0=none, 1=strong)."
+        },
+        "provenance": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1,
+          "description": "provenance control efficacy (0=none, 1=strong)."
+        },
+        "integrity": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1,
+          "description": "integrity control efficacy (0=none, 1=strong)."
+        },
+        "distribution": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1,
+          "description": "distribution control efficacy (0=none, 1=strong)."
+        },
+        "monitoring": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1,
+          "description": "monitoring control efficacy (0=none, 1=strong)."
+        }
+      }
+    },
+    "residualScore": {
+      "type": "number",
+      "minimum": 0,
+      "maximum": 1,
+      "description": "Residual risk after control efficacy (0..1)."
+    },
+    "rating": {
+      "type": "string",
+      "enum": [
+        "Low",
+        "Medium",
+        "High",
+        "Critical"
+      ]
+    },
+    "controlGaps": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "description": "Control families below tier-0 minimum evidence."
+    },
+    "note": {
+      "type": "string"
+    }
+  }
+}

--- a/schemas/RiskPath.json
+++ b/schemas/RiskPath.json
@@ -1,0 +1,73 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.srcos.ai/v2/RiskPath.json",
+  "title": "RiskPath",
+  "description": "Critical-service path risk — accumulates node residual scores across a supply chain. A path is only as strong as its weakest admitted node; concentration along the path compounds risk.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "id",
+    "type",
+    "specVersion",
+    "criticalService",
+    "nodeRefs",
+    "pathRisk",
+    "rating"
+  ],
+  "properties": {
+    "id": {
+      "type": "string",
+      "pattern": "^urn:srcos:risk-path:",
+      "description": "Stable URN. Pattern: urn:srcos:risk-path:<local-id>"
+    },
+    "type": {
+      "const": "RiskPath",
+      "description": "Discriminator — always \"RiskPath\"."
+    },
+    "specVersion": {
+      "type": "string",
+      "description": "Spec version, e.g. \"2.0.0\"."
+    },
+    "criticalService": {
+      "type": "string",
+      "minLength": 1
+    },
+    "serviceOwner": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "nodeRefs": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1,
+        "pattern": "^urn:srcos:risk-node:"
+      },
+      "description": "Ordered nodes on the critical service path."
+    },
+    "pathRisk": {
+      "type": "number",
+      "minimum": 0,
+      "maximum": 1,
+      "description": "Accumulated path risk (0..1)."
+    },
+    "rating": {
+      "type": "string",
+      "enum": [
+        "Low",
+        "Medium",
+        "High",
+        "Critical"
+      ]
+    },
+    "impactTolerance": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "description": "Tolerance for disruption (e.g. \"< 4h\")."
+    }
+  }
+}

--- a/schemas/SharedLibrary.json
+++ b/schemas/SharedLibrary.json
@@ -1,0 +1,52 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.srcos.ai/v2/SharedLibrary.json",
+  "title": "SharedLibrary",
+  "description": "A shared content/control library standardized once and inherited across objectives.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "id",
+    "type",
+    "specVersion",
+    "name",
+    "standardizes",
+    "repoAnchors"
+  ],
+  "properties": {
+    "id": {
+      "type": "string",
+      "pattern": "^urn:srcos:shared-library:",
+      "description": "Stable URN identifier. Pattern: urn:srcos:shared-library:<local-id>"
+    },
+    "type": {
+      "const": "SharedLibrary",
+      "description": "Discriminator constant — always \"SharedLibrary\"."
+    },
+    "specVersion": {
+      "type": "string",
+      "description": "Spec version of this document, e.g. \"2.0.0\"."
+    },
+    "name": {
+      "type": "string",
+      "minLength": 1
+    },
+    "standardizes": {
+      "type": "string",
+      "minLength": 1,
+      "description": "What the library standardizes."
+    },
+    "repoAnchors": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "description": "Primary repositories the library is anchored in."
+    },
+    "usedBy": {
+      "type": "string",
+      "description": "Which objective families inherit it."
+    }
+  }
+}

--- a/schemas/TripartyBundle.json
+++ b/schemas/TripartyBundle.json
@@ -1,0 +1,81 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.srcos.ai/v2/TripartyBundle.json",
+  "title": "TripartyBundle",
+  "description": "A typed, proof-carrying bundle that moves a netting cell through one lifecycle step. Bundle kinds mirror the settlement flow; each carries payload + proof + attestation so release is a function of evidence, admissibility, and freshness — not confidence.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "id",
+    "type",
+    "specVersion",
+    "kind",
+    "cellRef",
+    "payload",
+    "truthClass"
+  ],
+  "properties": {
+    "id": {
+      "type": "string",
+      "pattern": "^urn:srcos:triparty-bundle:",
+      "description": "Stable URN identifier. Pattern: urn:srcos:triparty-bundle:<local-id>"
+    },
+    "type": {
+      "const": "TripartyBundle",
+      "description": "Discriminator constant — always \"TripartyBundle\"."
+    },
+    "specVersion": {
+      "type": "string",
+      "description": "Spec version, e.g. \"2.0.0\"."
+    },
+    "kind": {
+      "type": "string",
+      "enum": [
+        "intent",
+        "acceptance",
+        "escrow",
+        "fill",
+        "verification",
+        "export"
+      ],
+      "description": "Bundle kind: intent→acceptance→escrow→fill→verification→export."
+    },
+    "cellRef": {
+      "type": "string",
+      "pattern": "^urn:srcos:netting-cell:",
+      "description": "The netting cell this bundle advances."
+    },
+    "payload": {
+      "type": "object",
+      "description": "Kind-specific payload (terms, fill metadata, verification result, export scope)."
+    },
+    "proofRef": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "description": "Packet/state proof (freshness, replay-safety)."
+    },
+    "attestationRef": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "description": "Witness/attestation (provenance + independence) — the Truth Record backing this bundle."
+    },
+    "truthClass": {
+      "type": "string",
+      "enum": [
+        "PROVEN",
+        "ATTESTED",
+        "INFERRED",
+        "REPUTED"
+      ],
+      "description": "Truth class this bundle asserts."
+    },
+    "issuedAt": {
+      "type": "string",
+      "description": "ISO-8601 issue time (freshness)."
+    }
+  }
+}

--- a/schemas/TrustEvent.json
+++ b/schemas/TrustEvent.json
@@ -1,0 +1,62 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.srcos.ai/v2/TrustEvent.json",
+  "title": "TrustEvent",
+  "description": "Updates reputation through an evidenced event tied to a real request/award — reference, verification, completion, dispute, appeal, or correction. The reputation primitive is fulfillment history, not follower counts.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "id",
+    "type",
+    "specVersion",
+    "subjectRef",
+    "kind"
+  ],
+  "properties": {
+    "id": {
+      "type": "string",
+      "pattern": "^urn:srcos:trust-event:",
+      "description": "Stable URN. Pattern: urn:srcos:trust-event:<local-id>"
+    },
+    "type": {
+      "const": "TrustEvent",
+      "description": "Discriminator — always \"TrustEvent\"."
+    },
+    "specVersion": {
+      "type": "string",
+      "description": "Spec version, e.g. \"2.0.0\"."
+    },
+    "subjectRef": {
+      "type": "string",
+      "description": "The party whose fulfillment history this updates."
+    },
+    "kind": {
+      "type": "string",
+      "enum": [
+        "reference",
+        "verification",
+        "completion",
+        "dispute",
+        "appeal",
+        "correction"
+      ]
+    },
+    "requestRef": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "pattern": "^urn:srcos:labor-request:",
+      "description": "The request/award this event is tied to — reputation is fulfillment-anchored."
+    },
+    "evidenceRef": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "issuedAt": {
+      "type": "string"
+    }
+  }
+}

--- a/tools/validate_agentic_os_examples.py
+++ b/tools/validate_agentic_os_examples.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+"""Validate the agentic operating-system contract examples against their schemas.
+
+Covers the objects the agentic OS coordinates: Opportunity (objective), AgentPod
+(the staffing unit whose URN is also referenced by AgentMachineReceipt.agentPodRef),
+SharedLibrary, ReadinessScore, CaptureCadence, and CaptureDelta.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import jsonschema
+
+ROOT = Path(__file__).resolve().parents[1]
+PAIRS = [
+    (ROOT / "schemas" / "AgentPod.json", ROOT / "examples" / "agent_pod.json"),
+    (ROOT / "schemas" / "SharedLibrary.json", ROOT / "examples" / "shared_library.json"),
+    (ROOT / "schemas" / "ReadinessScore.json", ROOT / "examples" / "readiness_score.json"),
+    (ROOT / "schemas" / "CaptureDelta.json", ROOT / "examples" / "capture_delta.json"),
+    (ROOT / "schemas" / "CaptureCadence.json", ROOT / "examples" / "capture_cadence.json"),
+    (ROOT / "schemas" / "Opportunity.json", ROOT / "examples" / "opportunity.json"),
+]
+
+
+def validate_pair(schema_path: Path, example_path: Path) -> None:
+    schema = json.loads(schema_path.read_text(encoding="utf-8"))
+    jsonschema.validators.validator_for(schema).check_schema(schema)
+    example = json.loads(example_path.read_text(encoding="utf-8"))
+    jsonschema.validate(example, schema)
+
+
+def main() -> int:
+    checks: dict[str, bool] = {}
+    for schema_path, example_path in PAIRS:
+        validate_pair(schema_path, example_path)
+        checks[example_path.name] = True
+    print(json.dumps({"ok": all(checks.values()), "checks": checks}, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/validate_labor_market_examples.py
+++ b/tools/validate_labor_market_examples.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+"""Validate the request-centric labor-market contract examples.
+
+Labor is modeled as request + response + evidence + fulfillment + trust — NOT
+identity + feed + attention. Covers LaborRequest (the structured ask),
+LaborResponse (the proposal), FitScore (request<->response fit; never a global
+human-worth score), LaborAward (the accepted arrangement + work ledger), and
+TrustEvent (reputation from evidenced fulfillment).
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import jsonschema
+
+ROOT = Path(__file__).resolve().parents[1]
+PAIRS = [
+    (ROOT / "schemas" / "LaborRequest.json", ROOT / "examples" / "labor_request.json"),
+    (ROOT / "schemas" / "LaborResponse.json", ROOT / "examples" / "labor_response.json"),
+    (ROOT / "schemas" / "FitScore.json", ROOT / "examples" / "fit_score.json"),
+    (ROOT / "schemas" / "LaborAward.json", ROOT / "examples" / "labor_award.json"),
+    (ROOT / "schemas" / "TrustEvent.json", ROOT / "examples" / "trust_event.json"),
+]
+
+
+def validate_pair(schema_path: Path, example_path: Path) -> None:
+    schema = json.loads(schema_path.read_text(encoding="utf-8"))
+    jsonschema.validators.validator_for(schema).check_schema(schema)
+    example = json.loads(example_path.read_text(encoding="utf-8"))
+    jsonschema.validate(example, schema)
+
+
+def main() -> int:
+    checks: dict[str, bool] = {}
+    for schema_path, example_path in PAIRS:
+        validate_pair(schema_path, example_path)
+        checks[example_path.name] = True
+    print(json.dumps({"ok": all(checks.values()), "checks": checks}, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/validate_supply_chain_risk_examples.py
+++ b/tools/validate_supply_chain_risk_examples.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+"""Validate the supply-chain operational-risk contract examples.
+
+A bank-style operational-risk framework applied to software/physical supply
+chains (BIAN Operational Risk Models / FICO decisioning aligned): RiskNode
+(inherent factors + control efficacy -> residual), RiskPath (accumulated node
+residuals along a critical service), RiskCluster (common-mode / HHI concentration),
+and RiskIndicator (KRI/KCI thresholds).
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import jsonschema
+
+ROOT = Path(__file__).resolve().parents[1]
+PAIRS = [
+    (ROOT / "schemas" / "RiskNode.json", ROOT / "examples" / "risk_node.json"),
+    (ROOT / "schemas" / "RiskPath.json", ROOT / "examples" / "risk_path.json"),
+    (ROOT / "schemas" / "RiskCluster.json", ROOT / "examples" / "risk_cluster.json"),
+    (ROOT / "schemas" / "RiskIndicator.json", ROOT / "examples" / "risk_indicator.json"),
+]
+
+
+def validate_pair(schema_path: Path, example_path: Path) -> None:
+    schema = json.loads(schema_path.read_text(encoding="utf-8"))
+    jsonschema.validators.validator_for(schema).check_schema(schema)
+    example = json.loads(example_path.read_text(encoding="utf-8"))
+    jsonschema.validate(example, schema)
+
+
+def main() -> int:
+    checks: dict[str, bool] = {}
+    for schema_path, example_path in PAIRS:
+        validate_pair(schema_path, example_path)
+        checks[example_path.name] = True
+    print(json.dumps({"ok": all(checks.values()), "checks": checks}, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/validate_triparty_examples.py
+++ b/tools/validate_triparty_examples.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+"""Validate the governed-triparty marketplace contract examples.
+
+Covers the settlement/marketplace primitives: NettingCell (the triparty clearing
+cell that couples value + proof + authority + disclosure) and TripartyBundle (the
+typed, proof-carrying bundle that advances a cell through its lifecycle).
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import jsonschema
+
+ROOT = Path(__file__).resolve().parents[1]
+PAIRS = [
+    (ROOT / "schemas" / "NettingCell.json", ROOT / "examples" / "netting_cell.json"),
+    (ROOT / "schemas" / "TripartyBundle.json", ROOT / "examples" / "triparty_bundle.json"),
+]
+
+
+def validate_pair(schema_path: Path, example_path: Path) -> None:
+    schema = json.loads(schema_path.read_text(encoding="utf-8"))
+    jsonschema.validators.validator_for(schema).check_schema(schema)
+    example = json.loads(example_path.read_text(encoding="utf-8"))
+    jsonschema.validate(example, schema)
+
+
+def main() -> int:
+    checks: dict[str, bool] = {}
+    for schema_path, example_path in PAIRS:
+        validate_pair(schema_path, example_path)
+        checks[example_path.name] = True
+    print(json.dumps({"ok": all(checks.values()), "checks": checks}, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Consolidates the four cockpit handoff-spec contracts (superseding #191, #192, #193, #194) into one canonical pack.

## Contracts
- **agentic-os** — `AgentPod`, `Opportunity`, `ReadinessScore`, `CaptureCadence`, `CaptureDelta`, `SharedLibrary` (VA capture as the agentic OS over the stack; composes over prophet-workspace authorities)
- **triparty** — `NettingCell`, `TripartyBundle` (governed-triparty marketplace)
- **labor-market** — `LaborRequest`, `LaborResponse`, `FitScore`, `LaborAward`, `TrustEvent` (request-centric; fit is scored request↔response, never a global human-worth score)
- **supply-chain-risk** — `RiskNode`, `RiskPath`, `RiskCluster`, `RiskIndicator` (BIAN operational-risk / FICO decisioning)

## Validation
17 schemas + 17 examples; the Makefile aggregates the four new `validate-*` targets into `make validate`. All four pass.

Backs the client-vue cockpit consoles (`/agentic-os`, `/marketplace`, `/people/labor-market`, `/operations/supply-chain`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)