### PR TITLE
fix(control-plane): green the example validation (validator crash + schema contradiction + broken JSON)

### DIFF
--- a/examples/boot_release_set.json
+++ b/examples/boot_release_set.json
@@ -2,14 +2,6 @@
   "boot_release_set_id": "urn:srcos:boot-release-set:m2-demo-recovery-2026-04-26",
   "base_release_set_ref": "urn:srcos:release-set:m2-demo-2026-04-26",
   "boot_mode": "recovery",
-  "status": "ready",
-  "artifacts": {
-    "kernel_ref": "urn:srcos:artifact:m2-demo-recovery-kernel-sha256-0f3b6d7f",
-    "initrd_ref": "urn:srcos:artifact:m2-demo-recovery-initrd-sha256-08f4c82e",
-    "rootfs_ref": "urn:srcos:artifact:m2-demo-recovery-rootfs-sha256-5f4dcc3b"
-  },
-  "created_at": "2026-04-26T14:30:00Z",
-  "notes": "SourceOS Recovery Environment for the M2 local-first demo. This models the nlboot-evolved recovery path: minimal boot artifacts, signed content-addressed refs, and linkage back to the assigned ReleaseSet."
   "boot_channel": "rescue",
   "status": "ready",
   "platform_entrypoints": [

--- a/schemas/control-plane/Fingerprint.json
+++ b/schemas/control-plane/Fingerprint.json
@@ -2,8 +2,8 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://schemas.srcos.ai/v2/control-plane/Fingerprint.json",
   "title": "Fingerprint",
-  "description": "Canonical Fingerprint schema. Wrapper that preserves legacy identifier while providing a stable srcos namespace for new references.",
+  "description": "Canonical Fingerprint schema. Control-plane wrapper that delegates to the canonical v2 Fingerprint contract (camelCase envelope), keeping a stable srcos control-plane namespace.",
   "allOf": [
-    { "$ref": "./fingerprint.schema.json" }
+    { "$ref": "../Fingerprint.json" }
   ]
 }

--- a/schemas/control-plane/ReleaseSet.json
+++ b/schemas/control-plane/ReleaseSet.json
@@ -2,8 +2,8 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://schemas.srcos.ai/v2/control-plane/ReleaseSet.json",
   "title": "ReleaseSet",
-  "description": "Canonical ReleaseSet schema. Wrapper that preserves legacy identifier while providing a stable srcos namespace for new references.",
+  "description": "Canonical ReleaseSet schema. Control-plane wrapper that delegates to the canonical v2 ReleaseSet contract (camelCase envelope), keeping a stable srcos control-plane namespace.",
   "allOf": [
-    { "$ref": "./release-set.schema.json" }
+    { "$ref": "../ReleaseSet.json" }
   ]
 }

--- a/tools/validate_control_plane_examples.py
+++ b/tools/validate_control_plane_examples.py
@@ -19,7 +19,9 @@ def validate_pair(schema_path: Path, example_path: Path) -> None:
     schema = json.loads(schema_path.read_text(encoding="utf-8"))
     jsonschema.validators.validator_for(schema).check_schema(schema)
     legacy_ref = schema.get("allOf", [{}])[0].get("$ref")
-    validation_schema_path = schema_path.with_name(legacy_ref) if legacy_ref else schema_path
+    # The wrapper schema delegates validation to the legacy sibling schema it $refs
+    # (a relative path like "./release-set.schema.json"), so resolve it against the
+    # wrapper's directory. (Path.with_name rejects names containing "/".)
     validation_schema_path = (schema_path.parent / legacy_ref).resolve() if legacy_ref else schema_path
     validation_schema = json.loads(validation_schema_path.read_text(encoding="utf-8"))
     example = json.loads(example_path.read_text(encoding="utf-8"))


### PR DESCRIPTION
The control-plane contract check — surfaced via the **"Validate OpsHistory contracts"** CI job, which runs the whole `make validate` aggregate — has been **red on `main` for ~2 months**, independent of the cockpit contract pack (#195). This fixes it with a minimal, 4-file change.

## Three distinct defects

1. **Validator crash** — `tools/validate_control_plane_examples.py` called `Path.with_name("./release-set.schema.json")`, which raises `ValueError` (`with_name` rejects names containing `/`). The correct `(schema_path.parent / legacy_ref).resolve()` already sat on the next line; removed the dead/crashing one.

2. **Contradictory schemas for one example** (the core breakage). `examples/release_set.json` and `examples/fingerprint.json` are validated by **both** validators:
   - `validate-control-plane-examples` → the control-plane wrappers, which `allOf`-delegated to the **legacy snake_case** schemas (`release_set_id`, `created_at`, …)
   - `validate-nlboot-examples` → the canonical **v2 camelCase** schemas (`id`/`type`/`specVersion`, `createdAt`, …)

   Both are `additionalProperties: false` with mutually exclusive key sets, so **no single document can satisfy both** — unfixable at the example level. Repointed the two shared wrappers (`schemas/control-plane/ReleaseSet.json`, `Fingerprint.json`) to delegate to the canonical v2 contracts (`../ReleaseSet.json`, `../Fingerprint.json`) — matching the wrappers' stated purpose of "providing a stable srcos namespace." `BootReleaseSet`/`EnrollmentToken` keep their legacy snake schemas (only the control-plane validator checks them; no v2 equivalent).

3. **Invalid JSON** — `examples/boot_release_set.json` was a botched merge (from `a2b9dc9` into `work/boot-provisioning-examples`): two object bodies concatenated (missing comma after the first block's `notes`, duplicate `status`/`artifacts`/`created_at`/`notes`). Reconstructed as the single valid union its rich schema requires (identity fields + the fuller recovery body).

## Result
`make validate` now passes end-to-end — control-plane, nlboot, and all other families:
```
OK: validate
```

Note: this is the **control-plane / boot-provisioning** lane. The boot JSON repair reconstructs the intended union of that workstream's merge; worth a glance from its owner to confirm the reconstructed `boot_release_set.json` matches intent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)