### PR TITLE
fix(ci): repair the Validate Spec workflow + complete the CompressionEvaluation schema

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -42,11 +42,11 @@ jobs:
           done
           exit $failed
 
-      - name: Guardrail: detect duplicate schema $id values
+      - name: "Guardrail: detect duplicate schema $id values"
         run: |
           python3 scripts/check_duplicate_schema_ids.py
 
-      - name: Guardrail: control-plane canonical wrapper $id resolution
+      - name: "Guardrail: control-plane canonical wrapper $id resolution"
         run: |
           python3 scripts/validate_control_plane_wrapper_ids.py
 

--- a/schemas/CompressionEvaluation.json
+++ b/schemas/CompressionEvaluation.json
@@ -79,8 +79,14 @@
       "properties": {
         "novelty": { "type": "number", "description": "Primary novelty signal." },
         "redundancy": { "type": "number", "description": "Primary redundancy signal." },
+        "supportingMetrics": {
+          "type": ["object", "null"],
+          "additionalProperties": { "type": "number" },
+          "description": "Optional named supporting metrics (e.g. support, stability)."
+        },
         "confidence": { "type": ["number", "null"], "description": "Optional confidence score." },
-        "warnings": { "type": "array", "items": { "type": "string" }, "description": "Optional warnings." }
+        "warnings": { "type": "array", "items": { "type": "string" }, "description": "Optional warnings." },
+        "normalizationVersion": { "type": ["string", "null"], "description": "Optional version of the metric normalization applied." }
       }
     },
     "policyDecisionRef": {
@@ -97,6 +103,31 @@
       "type": ["string", "null"],
       "pattern": "^urn:srcos:prov:",
       "description": "Optional provenance reference."
+    },
+    "truthSurfaceRef": {
+      "type": ["string", "null"],
+      "pattern": "^urn:srcos:truth-surface:",
+      "description": "Optional reference to the truth surface this evaluation is grounded against."
+    },
+    "deltaSurfaceRef": {
+      "type": ["string", "null"],
+      "pattern": "^urn:srcos:delta-surface:",
+      "description": "Optional reference to the delta surface produced by this evaluation."
+    },
+    "integrity": {
+      "type": ["object", "null"],
+      "additionalProperties": false,
+      "description": "Optional signed integrity envelope for the evaluation record.",
+      "properties": {
+        "evaluationHash": { "type": "string", "description": "Content hash of the evaluation." },
+        "signer": { "type": ["string", "null"], "description": "Identity of the signer." },
+        "signature": { "type": ["string", "null"], "description": "Detached signature over the evaluation hash." },
+        "signedAt": { "type": ["string", "null"], "format": "date-time", "description": "Signing timestamp." }
+      }
+    },
+    "notes": {
+      "type": ["string", "null"],
+      "description": "Optional human-readable notes."
     },
     "createdAt": {
       "type": "string",


### PR DESCRIPTION
Greens the **last dark workflow** on `main`. Companion to #196 (which fixed the OpsHistory/`make validate` check).

## Two coupled fixes

1. **`.github/workflows/validate.yml` failed in 0s on every commit for weeks** ("This run likely failed because of a workflow file issue") — invalid YAML: two step `name:` values contained an unquoted colon (`Guardrail: detect duplicate schema $id values`), which YAML parses as a nested mapping, so GitHub rejected the whole file. Quoted both names. `yaml.safe_load` now parses clean.

2. Un-breaking the workflow makes its dormant jobs run, which **unmasked one content failure**: `examples/compressionevaluation.json` carried fields absent from `schemas/CompressionEvaluation.json` (which is `additionalProperties: false`): `truthSurfaceRef`, `deltaSurfaceRef`, `integrity` (`evaluationHash`/`signer`/`signature`/`signedAt`), `notes`, plus `metrics.supportingMetrics` and `metrics.normalizationVersion`. These are intentional (surface refs + a signed integrity envelope), so I added them to the schema as **optional** properties — additive, non-breaking.

## Verified locally (all `validate.yml` jobs)
- `validate.yml` parses; no other unquoted-colon `name:` in `.github/workflows/`
- **all 263 top-level schemas compile under `ajv`** (the exact workflow loop) — no latent failures
- both guardrail scripts pass (`check_duplicate_schema_ids.py`, `validate_control_plane_wrapper_ids.py`)
- by-type example validation: **170 passed / 81 skipped / 0 failed**
- `openapi.yaml` / `asyncapi.yaml` / `semantic/*.jsonld` all parse
- `make validate` green end-to-end

After this, `main` is green across every workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)